### PR TITLE
Do not disrupt message position when buffer is destroyed

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -61,8 +61,8 @@ export default class Buffer {
       this.markers[message.key] = marker
       this.messages.add(message)
       this.applyMarker(message, this.editors)
-      marker.onDidChange(({ newHeadBufferPosition, newTailBufferPosition, isValid }) => {
-        if (isValid) {
+      marker.onDidChange(({ oldHeadBufferPosition, newHeadBufferPosition, newTailBufferPosition, isValid }) => {
+        if (isValid && (newHeadBufferPosition !== 0 || oldHeadBufferPosition === 0)) {
           message.range = [newHeadBufferPosition, newTailBufferPosition]
         }
       })


### PR DESCRIPTION
Now it only accepts 0 for a line number on an updated marker if the last line number was zero as well, this prevents destruction of the message range when the marker is being destroyed.
Normally the it doesn't matter what happens to a message after the editor it is pointing to is closed, but in the case of project scoped linters we have to restart/reload the Editor to fix it

Fixes #58