### PR TITLE
Support selected attribute for messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add `messageTypesToIgnoreInPanel` config
 - Fix a bug with Atom where it would null out ranges in messages of project scoped linters
 - Add next and previous error commands
+- Add support for `selected` attribute on linter messages
 
 ### v0.0.3
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -29,6 +29,9 @@ export function visitMessage(message: Linter$Message): Promise {
       // $FlowIgnore: Flow doesn't believe me
       textEditor.setCursorBufferPosition(message.range[0] || message.range.start)
     }
+    if (typeof message.selected === 'function') {
+      message.selected(message)
+    }
   })
 }
 

--- a/spec/helpers-spec.js
+++ b/spec/helpers-spec.js
@@ -1,0 +1,45 @@
+'use babel'
+
+import { visitMessage } from '../lib/helpers'
+
+describe('Helpers', function() {
+  afterEach(function() {
+    atom.workspace.destroyActivePaneItem()
+  })
+
+  describe('visitMessage', function() {
+    it('opens the file in message', function() {
+      waitsForPromise(function() {
+        return visitMessage({ filePath: __filename }).then(function() {
+          const textEditor = atom.workspace.getActiveTextEditor()
+          expect(textEditor.getPath()).toBe(__filename)
+        })
+      })
+    })
+
+    it('sets the cursor position properly', function() {
+      waitsForPromise(function() {
+        return visitMessage({ filePath: __filename, range: [[5, 0], [5, 5]] }).then(function() {
+          const textEditor = atom.workspace.getActiveTextEditor()
+          const cursorPosition = textEditor.getCursorBufferPosition()
+          expect(cursorPosition.row).toBe(5)
+          expect(cursorPosition.column).toBe(0)
+        })
+      })
+    })
+
+    it('triggers the selected callback if any', function() {
+      const selected = jasmine.createSpy('selected')
+      const message = { filePath: __filename, selected }
+
+      waitsForPromise(function() {
+        return visitMessage(message).then(function() {
+          expect(selected).toHaveBeenCalled()
+          expect(selected.calls.length).toBe(1)
+          expect(selected.mostRecentCall.args.length).toBe(1)
+          expect(selected.mostRecentCall.args[0]).toBe(message)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
It's gonna be a callback that has the message as the first parameter so it works with arrow functions

Fixes https://github.com/steelbrain/linter/issues/1106

- [x] Implement support
- [x] Add specifications
- [x] Document change in CHANGELOG
- [x] Update wiki