### PR TITLE
add clipboard icon to linter messages

### DIFF
--- a/lib/elements/message.js
+++ b/lib/elements/message.js
@@ -27,6 +27,9 @@ export default class Message extends React.Component {
     linkContent += ` in ${atom.project.relativizePath(message.filePath)[1]}`
     return <a href="#" className="linter-message-link" onClick={() => visitMessage(message) }>{ linkContent }</a>
   }
+  static getCopyLink(message: Linter$Message) {
+    return <a href="#" className="linter-message-copy-link" onClick={() => atom.clipboard.write(message.text || message.html) } />
+  }
   static getSingleLineMessage(message: Linter$Message, includeLink: boolean) {
     const number = ++MESSAGE_NUMBER
     const elementID = `linter-message-${number}`
@@ -76,6 +79,7 @@ export default class Message extends React.Component {
   render() {
     const { message, includeLink, includeProvider } = this.props
     return (<linter-message>
+      { Message.getCopyLink(message) }
       { includeProvider && message.name ? Message.getName(message) : null }
       { Message.getRibbon(message) }
       { message.multiline || NEWLINE.test(message.text || '') ?

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -28,6 +28,13 @@ linter-message {
   margin: 0 0 0 @spacing;
 }
 
+.linter-message-copy-link {
+  &::before {
+    font-family: 'Octicons Regular';
+    content: @clippy;
+  }
+}
+
 linter-message-line {
   white-space: pre-wrap; /* Enable whitespace to be maintained from the user message. */
 }


### PR DESCRIPTION
fixes #78 

![screenshot from 2016-05-18 13-44-57](https://cloud.githubusercontent.com/assets/332036/15357399/de70f53a-1cfe-11e6-96af-2db5f4054a8d.png)
