### PR TITLE
Expand single messages

### DIFF
--- a/lib/tooltip/index.js
+++ b/lib/tooltip/index.js
@@ -38,12 +38,13 @@ export default class TooltipElement {
     this.subscriptions.add(delegate)
 
     const children = []
+    const single = messages.length === 1
     messages.forEach((message) => {
       if (message.version === 2) {
-        children.push(<MessageElement key={message.key} delegate={delegate} message={message} />)
+        children.push(<MessageElement key={message.key} delegate={delegate} message={message} single={single} />)
         return
       }
-      children.push(<MessageElementLegacy key={message.key} delegate={delegate} message={message} />)
+      children.push(<MessageElementLegacy key={message.key} delegate={delegate} message={message} single={single} />)
       if (message.trace && message.trace.length) {
         children.push(...message.trace.map((trace, index) =>
           <MessageElementLegacy key={`${trace.key}:trace:${index}`} delegate={delegate} message={trace} />

--- a/lib/tooltip/message-legacy.js
+++ b/lib/tooltip/message-legacy.js
@@ -12,6 +12,7 @@ export default class Message extends React.Component {
   props: {
     message: MessageLegacy,
     delegate: TooltipDelegate,
+    single: boolean,
   };
   state: {
     multiLineShow: boolean,
@@ -28,6 +29,10 @@ export default class Message extends React.Component {
     this.props.delegate.onShouldCollapse(() => {
       this.setState({ multiLineShow: false })
     })
+
+    if (this.props.single) {
+      this.setState({ multiLineShow: true })
+    }
   }
   render() {
     return NEWLINE.test(this.props.message.text || '') ? this.renderMultiLine() : this.renderSingleLine()

--- a/lib/tooltip/message.js
+++ b/lib/tooltip/message.js
@@ -11,6 +11,7 @@ export default class MessageElement extends React.Component {
   props: {
     message: Message,
     delegate: TooltipDelegate,
+    single: boolean,
   };
   state: {
     description: string,
@@ -35,6 +36,10 @@ export default class MessageElement extends React.Component {
         this.toggleDescription()
       }
     })
+
+    if (this.props.single) {
+      this.toggleDescription()
+    }
   }
   toggleDescription(result: ?string = null) {
     const newStatus = !this.state.descriptionShow


### PR DESCRIPTION
This is an experiment that probably needs more discussion before it can be merged. It would be a solution for 314eter/atom-ocaml-merlin#27.

The problem is that the only way to display multiline messages with correct indentation, is in a code block in the description. In that case, I can't think of anything better to put in the excerpt than "Error" or "Warning". This is annoying, because you can't see anything useful without manually expanding the description.

My solution is to expand the description by default, if there is only one message to show.