### PR TITLE
Fix: Inconsistent border-radius of status indicator

### DIFF
--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -120,7 +120,16 @@ atom-text-editor.editor .linter-highlight, .linter-highlight {
 
 .linter-status-count {
   span {
+    border-radius: 0px;
     padding: 4px 6px;
+  }
+  span:first-child {
+    border-top-left-radius: @component-border-radius;
+    border-bottom-left-radius: @component-border-radius;
+  }
+  span:last-child {
+    border-top-right-radius: @component-border-radius;
+    border-bottom-right-radius: @component-border-radius;
   }
   &.hide-config, &.hide-pane {
     display: none;


### PR DESCRIPTION
The status indicator has a inconsistent border radius.

With the One Light theme this is hardly noticeable, but with the One Dark theme this is quite prominent.

**master**
![bildschirmfoto 2017-04-01 um 23 48 22](https://cloud.githubusercontent.com/assets/13285808/24582757/1cfe512a-1737-11e7-9a57-af45e16fe1ce.png)![bildschirmfoto 2017-04-01 um 23 48 30](https://cloud.githubusercontent.com/assets/13285808/24582758/1cffc9c4-1737-11e7-9b58-4c0224ccf305.png)

**PR**
![bildschirmfoto 2017-04-01 um 23 47 29](https://cloud.githubusercontent.com/assets/13285808/24582763/29a505ea-1737-11e7-89b2-c208c432c332.png)![bildschirmfoto 2017-04-01 um 23 47 15](https://cloud.githubusercontent.com/assets/13285808/24582764/29a5f518-1737-11e7-875b-4bc57ccbaccc.png)
