### PR TITLE
Fix link for v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Upcoming
 
+* Fix link for v1 `html` message providers
 * Fix inconsistent border radius of Linter Status
 
 ## 1.2.2

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -129,7 +129,7 @@ export function openExternally(message: LinterMessage): void {
     link = message.url
   } else {
     // $FlowIgnore: Flow is dumb
-    searchTerm = `${message.linterName} ${message.excerpt || (String(message.text) || htmlToText(message.html || ''))}`
+    searchTerm = `${message.linterName} ${message.excerpt || (message.text || htmlToText(message.html || ''))}`
   }
   link = link || `https://google.com/search?q=${encodeURIComponent(searchTerm)}`
   shell.openExternal(link)


### PR DESCRIPTION
Previously we were doing `String(message.text) || htmlToText(message.html)`, we didn't notice the bug because most providers use `message.text` but for those who don't the runtime values end up looking like `"Undefined" || "value"`, and because string undefined is actually not undefined, it would use that as search term.

This PR aims to fix that