### PR TITLE
Reduce activation time

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,7 @@
     "no-duplicate-imports": "off",
     "no-underscore-dangle": "off",
     "react/no-danger": "off",
-    "react/no-danger-with-children": "off"
+    "react/no-danger-with-children": "off",
+    "global-require": "off"
   }
 }

--- a/decls/atom.js
+++ b/decls/atom.js
@@ -15,6 +15,9 @@ declare module 'atom' {
   declare var BufferMarker: any;
   declare var TextEditorGutter: any;
   declare var TextEditorMarker: any;
+  declare var Disposable: any;
+  declare var CompositeDisposable: any;
+  declare var Emitter: any;
 }
 
 declare module 'electron' {

--- a/decls/atom.js
+++ b/decls/atom.js
@@ -7,17 +7,17 @@ declare var atom: Object;
 declare var CSS: Object;
 
 declare module 'atom' {
+  declare var Panel: any;
   declare var Point: any;
   declare var Range: any;
-  declare var Panel: any;
+  declare var Emitter: any;
+  declare var Disposable: any;
   declare var TextEditor: any;
   declare var TextBuffer: any;
   declare var BufferMarker: any;
   declare var TextEditorGutter: any;
   declare var TextEditorMarker: any;
-  declare var Disposable: any;
   declare var CompositeDisposable: any;
-  declare var Emitter: any;
 }
 
 declare module 'electron' {

--- a/decls/jasmine.js
+++ b/decls/jasmine.js
@@ -6,6 +6,6 @@ declare function fit(name: string, callback: (() => void)): void;
 declare function spyOn(object: Object, property: string): Object;
 declare function expect(value: any): Object;
 declare function describe(name: string, callback: (() => void)): void;
+declare function afterEach(callback: (() => void)): void;
 declare function fdescribe(name: string, callback: (() => void)): void;
 declare function beforeEach(callback: (() => void)): void;
-declare function afterEach(callback: (() => void)): void;

--- a/lib/busy-signal.js
+++ b/lib/busy-signal.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { CompositeDisposable } from 'sb-event-kit'
+import { CompositeDisposable } from 'atom'
 import type { Linter } from './types'
 
 export default class BusySignal {

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1,21 +1,18 @@
 /* @flow */
 
-import { CompositeDisposable, Emitter } from 'atom'
+import { CompositeDisposable } from 'atom'
 
 import { $file, $range, visitMessage, sortMessages, sortSolutions, filterMessages, applySolution } from './helpers'
 import type { LinterMessage } from './types'
 
 export default class Commands {
-  emitter: Emitter;
   messages: Array<LinterMessage>;
   subscriptions: CompositeDisposable;
 
   constructor() {
-    this.emitter = new Emitter()
     this.messages = []
     this.subscriptions = new CompositeDisposable()
 
-    this.subscriptions.add(this.emitter)
     this.subscriptions.add(atom.commands.add('atom-workspace', {
       'linter-ui-default:next': () => this.move(true, true),
       'linter-ui-default:previous': () => this.move(false, true),

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { CompositeDisposable, Emitter } from 'sb-event-kit'
+import { CompositeDisposable, Emitter } from 'atom'
 
 import { $file, $range, visitMessage, sortMessages, sortSolutions, filterMessages, applySolution } from './helpers'
 import type { LinterMessage } from './types'

--- a/lib/editor/index.js
+++ b/lib/editor/index.js
@@ -2,8 +2,7 @@
 
 import debounce from 'sb-debounce'
 import disposableEvent from 'disposable-event'
-import { Range } from 'atom'
-import { CompositeDisposable, Emitter, Disposable } from 'sb-event-kit'
+import { CompositeDisposable, Disposable, Emitter, Range } from 'atom'
 import type { TextEditor, BufferMarker, TextEditorGutter, Point } from 'atom'
 
 import Tooltip from '../tooltip'
@@ -66,9 +65,9 @@ export default class Editor {
       tooltipSubscription = tooltipFollows === 'Mouse' ? this.listenForMouseMovement() : this.listenForKeyboardMovement()
       this.removeTooltip()
     }))
-    this.subscriptions.add(function() {
+    this.subscriptions.add(new Disposable(function() {
       tooltipSubscription.dispose()
-    })
+    }))
     this.updateGutter()
     this.listenForCurrentLine()
   }
@@ -113,12 +112,12 @@ export default class Editor {
         handlePositionChange({ start: newHeadScreenPosition, end: newTailScreenPosition })
       }))
       subscriptions.add(cursor.onDidDestroy(() => {
-        this.subscriptions.delete(subscriptions)
+        this.subscriptions.remove(subscriptions)
         subscriptions.dispose()
       }))
-      subscriptions.add(function() {
+      subscriptions.add(new Disposable(function() {
         if (marker) marker.destroy()
-      })
+      }))
       this.subscriptions.add(subscriptions)
       handlePositionChange(cursorMarker.getScreenRange())
     }))

--- a/lib/editors.js
+++ b/lib/editors.js
@@ -1,26 +1,23 @@
 /* @flow */
 
-import { CompositeDisposable, Emitter } from 'atom'
+import { CompositeDisposable } from 'atom'
 import type { TextEditor } from 'atom'
 import Editor from './editor'
 import { $file, getEditorsMap, filterMessages } from './helpers'
 import type { LinterMessage, MessagesPatch } from './types'
 
 class Editors {
-  emitter: Emitter;
   editors: Set<Editor>;
   messages: Array<LinterMessage>;
   firstRender: bool;
   subscriptions: CompositeDisposable;
 
   constructor() {
-    this.emitter = new Emitter()
     this.editors = new Set()
     this.messages = []
     this.firstRender = true
     this.subscriptions = new CompositeDisposable()
 
-    this.subscriptions.add(this.emitter)
     this.subscriptions.add(atom.workspace.observeTextEditors((textEditor) => {
       this.getEditor(textEditor)
     }))

--- a/lib/editors.js
+++ b/lib/editors.js
@@ -6,7 +6,7 @@ import Editor from './editor'
 import { $file, getEditorsMap, filterMessages } from './helpers'
 import type { LinterMessage, MessagesPatch } from './types'
 
-export default class Editors {
+class Editors {
   emitter: Emitter;
   editors: Set<Editor>;
   messages: Array<LinterMessage>;
@@ -82,3 +82,5 @@ export default class Editors {
     this.subscriptions.dispose()
   }
 }
+
+module.exports = Editors

--- a/lib/editors.js
+++ b/lib/editors.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { CompositeDisposable, Emitter } from 'sb-event-kit'
+import { CompositeDisposable, Emitter } from 'atom'
 import type { TextEditor } from 'atom'
 import Editor from './editor'
 import { $file, getEditorsMap, filterMessages } from './helpers'

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,15 +15,13 @@ const linterUiDefault = {
       atom.packages.getLoadedPackage('linter-ui-default').metadata['package-deps'].push('busy-signal')
     }
 
-    let callbackID
-    const installLinterUIDefaultDeps = () => {
+    const callbackID = window.requestIdleCallback(function installLinterUIDefaultDeps() {
       idleCallbacks.delete(callbackID)
       if (!atom.inSpecMode()) {
         // eslint-disable-next-line global-require
         require('atom-package-deps').install('linter-ui-default')
       }
-    }
-    callbackID = window.requestIdleCallback(installLinterUIDefaultDeps)
+    })
     idleCallbacks.add(callbackID)
   },
   deactivate() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,8 @@
 import LinterUI from './main'
 import type Intentions from './intentions'
 
+const idleCallbacks = new Set()
+
 const linterUiDefault = {
   instances: new Set(),
   signalRegistry: null,
@@ -13,12 +15,20 @@ const linterUiDefault = {
       atom.packages.getLoadedPackage('linter-ui-default').metadata['package-deps'].push('busy-signal')
     }
 
-    if (!atom.inSpecMode()) {
-      // eslint-disable-next-line global-require
-      require('atom-package-deps').install('linter-ui-default', true)
+    let callbackID
+    const installLinterUIDefaultDeps = () => {
+      idleCallbacks.delete(callbackID)
+      if (!atom.inSpecMode()) {
+        // eslint-disable-next-line global-require
+        require('atom-package-deps').install('linter-ui-default')
+      }
     }
+    callbackID = window.requestIdleCallback(installLinterUIDefaultDeps)
+    idleCallbacks.add(callbackID)
   },
   deactivate() {
+    idleCallbacks.forEach(callbackID => window.cancelIdleCallback(callbackID))
+    idleCallbacks.clear()
     for (const entry of this.instances) {
       entry.dispose()
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,14 +1,15 @@
 /* @flow */
 
 import { CompositeDisposable } from 'sb-event-kit'
-import Panel from './panel'
-import Editors from './editors'
 import TreeView from './tree-view'
 import Commands from './commands'
 import StatusBar from './status-bar'
 import BusySignal from './busy-signal'
 import Intentions from './intentions'
 import type { Linter, LinterMessage, MessagesPatch } from './types'
+
+let Panel
+let Editors
 
 export default class LinterUI {
   name: string;
@@ -21,9 +22,11 @@ export default class LinterUI {
   statusBar: StatusBar;
   intentions: Intentions;
   subscriptions: CompositeDisposable;
+  idleCallbacks: Set<*>;
 
   constructor() {
     this.name = 'Linter'
+    this.idleCallbacks = new Set()
     this.signal = new BusySignal()
     this.treeview = new TreeView()
     this.commands = new Commands()
@@ -37,24 +40,43 @@ export default class LinterUI {
     this.subscriptions.add(this.commands)
     this.subscriptions.add(this.statusBar)
 
-    this.subscriptions.add(atom.config.observe('linter-ui-default.showPanel', (showPanel) => {
-      if (showPanel && !this.panel) {
-        this.panel = new Panel()
-        this.panel.update(this.messages)
-      } else if (!showPanel && this.panel) {
-        this.panel.dispose()
-        this.panel = null
-      }
-    }))
-    this.subscriptions.add(atom.config.observe('linter-ui-default.showDecorations', (showDecorations) => {
-      if (showDecorations && !this.editors) {
-        this.editors = new Editors()
-        this.editors.update({ added: this.messages, removed: [], messages: this.messages })
-      } else if (!showDecorations && this.editors) {
-        this.editors.dispose()
-        this.editors = null
-      }
-    }))
+    let obsShowPanelCB
+    const observeShowPanel = () => {
+      this.subscriptions.add(atom.config.observe('linter-ui-default.showPanel', (showPanel) => {
+        this.idleCallbacks.delete(obsShowPanelCB)
+        if (!Panel) {
+          Panel = require('./panel')
+        }
+        if (showPanel && !this.panel) {
+          this.panel = new Panel()
+          this.panel.update(this.messages)
+        } else if (!showPanel && this.panel) {
+          this.panel.dispose()
+          this.panel = null
+        }
+      }))
+    }
+    obsShowPanelCB = window.requestIdleCallback(observeShowPanel)
+    this.idleCallbacks.add(obsShowPanelCB)
+
+    let obsShowDecorationsCB
+    const observeShowDecorations = () => {
+      this.subscriptions.add(atom.config.observe('linter-ui-default.showDecorations', (showDecorations) => {
+        this.idleCallbacks.delete(obsShowDecorationsCB)
+        if (!Editors) {
+          Editors = require('./editors')
+        }
+        if (showDecorations && !this.editors) {
+          this.editors = new Editors()
+          this.editors.update({ added: this.messages, removed: [], messages: this.messages })
+        } else if (!showDecorations && this.editors) {
+          this.editors.dispose()
+          this.editors = null
+        }
+      }))
+    }
+    obsShowDecorationsCB = window.requestIdleCallback(observeShowDecorations)
+    this.idleCallbacks.add(obsShowDecorationsCB)
   }
   render(difference: MessagesPatch) {
     const editors = this.editors
@@ -82,6 +104,8 @@ export default class LinterUI {
     this.signal.didFinishLinting(linter, filePath)
   }
   dispose() {
+    this.idleCallbacks.forEach(callbackID => window.cancelIdleCallback(callbackID))
+    this.idleCallbacks.clear()
     this.subscriptions.dispose()
     if (this.panel) {
       this.panel.dispose()

--- a/lib/main.js
+++ b/lib/main.js
@@ -22,7 +22,7 @@ export default class LinterUI {
   statusBar: StatusBar;
   intentions: Intentions;
   subscriptions: CompositeDisposable;
-  idleCallbacks: Set<*>;
+  idleCallbacks: Set<number>;
 
   constructor() {
     this.name = 'Linter'

--- a/lib/main.js
+++ b/lib/main.js
@@ -38,8 +38,7 @@ export default class LinterUI {
     this.subscriptions.add(this.commands)
     this.subscriptions.add(this.statusBar)
 
-    let obsShowPanelCB
-    const observeShowPanel = () => {
+    const obsShowPanelCB = window.requestIdleCallback(function observeShowPanel() {
       this.subscriptions.add(atom.config.observe('linter-ui-default.showPanel', (showPanel) => {
         this.idleCallbacks.delete(obsShowPanelCB)
         if (!Panel) {
@@ -53,12 +52,10 @@ export default class LinterUI {
           this.panel = null
         }
       }))
-    }
-    obsShowPanelCB = window.requestIdleCallback(observeShowPanel)
+    }.bind(this))
     this.idleCallbacks.add(obsShowPanelCB)
 
-    let obsShowDecorationsCB
-    const observeShowDecorations = () => {
+    const obsShowDecorationsCB = window.requestIdleCallback(function observeShowDecorations() {
       this.subscriptions.add(atom.config.observe('linter-ui-default.showDecorations', (showDecorations) => {
         this.idleCallbacks.delete(obsShowDecorationsCB)
         if (!Editors) {
@@ -72,8 +69,7 @@ export default class LinterUI {
           this.editors = null
         }
       }))
-    }
-    obsShowDecorationsCB = window.requestIdleCallback(observeShowDecorations)
+    }.bind(this))
     this.idleCallbacks.add(obsShowDecorationsCB)
   }
   render(difference: MessagesPatch) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { CompositeDisposable } from 'sb-event-kit'
+import { CompositeDisposable } from 'atom'
 import TreeView from './tree-view'
 import Commands from './commands'
 import StatusBar from './status-bar'

--- a/lib/main.js
+++ b/lib/main.js
@@ -39,11 +39,11 @@ export default class LinterUI {
     this.subscriptions.add(this.statusBar)
 
     const obsShowPanelCB = window.requestIdleCallback(function observeShowPanel() {
+      this.idleCallbacks.delete(obsShowPanelCB)
+      if (!Panel) {
+        Panel = require('./panel')
+      }
       this.subscriptions.add(atom.config.observe('linter-ui-default.showPanel', (showPanel) => {
-        this.idleCallbacks.delete(obsShowPanelCB)
-        if (!Panel) {
-          Panel = require('./panel')
-        }
         if (showPanel && !this.panel) {
           this.panel = new Panel()
           this.panel.update(this.messages)
@@ -56,11 +56,11 @@ export default class LinterUI {
     this.idleCallbacks.add(obsShowPanelCB)
 
     const obsShowDecorationsCB = window.requestIdleCallback(function observeShowDecorations() {
+      this.idleCallbacks.delete(obsShowDecorationsCB)
+      if (!Editors) {
+        Editors = require('./editors')
+      }
       this.subscriptions.add(atom.config.observe('linter-ui-default.showDecorations', (showDecorations) => {
-        this.idleCallbacks.delete(obsShowDecorationsCB)
-        if (!Editors) {
-          Editors = require('./editors')
-        }
         if (showDecorations && !this.editors) {
           this.editors = new Editors()
           this.editors.update({ added: this.messages, removed: [], messages: this.messages })

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,6 @@
 /* @flow */
 
 import { CompositeDisposable } from 'atom'
-import TreeView from './tree-view'
 import Commands from './commands'
 import StatusBar from './status-bar'
 import BusySignal from './busy-signal'
@@ -10,6 +9,7 @@ import type { Linter, LinterMessage, MessagesPatch } from './types'
 
 let Panel
 let Editors
+let TreeView
 
 export default class LinterUI {
   name: string;
@@ -28,7 +28,6 @@ export default class LinterUI {
     this.name = 'Linter'
     this.idleCallbacks = new Set()
     this.signal = new BusySignal()
-    this.treeview = new TreeView()
     this.commands = new Commands()
     this.messages = []
     this.statusBar = new StatusBar()
@@ -36,7 +35,6 @@ export default class LinterUI {
     this.subscriptions = new CompositeDisposable()
 
     this.subscriptions.add(this.signal)
-    this.subscriptions.add(this.treeview)
     this.subscriptions.add(this.commands)
     this.subscriptions.add(this.statusBar)
 
@@ -89,11 +87,20 @@ export default class LinterUI {
         editors.update(difference)
       }
     }
+    // Initialize the TreeView subscription if necessary
+    if (!this.treeview) {
+      if (!TreeView) {
+        TreeView = require('./tree-view')
+      }
+      this.treeview = new TreeView()
+      this.subscriptions.add(this.treeview)
+    }
+    this.treeview.update(difference.messages)
+
     if (this.panel) {
       this.panel.update(difference.messages)
     }
     this.commands.update(difference.messages)
-    this.treeview.update(difference.messages)
     this.intentions.update(difference.messages)
     this.statusBar.update(difference.messages)
   }

--- a/lib/panel/delegate.js
+++ b/lib/panel/delegate.js
@@ -1,9 +1,7 @@
 /* @flow */
 
-import { Range } from 'atom'
-import { CompositeDisposable, Emitter } from 'sb-event-kit'
+import { CompositeDisposable, Disposable, Emitter, Range } from 'atom'
 import type { Panel } from 'atom'
-import type { Disposable } from 'sb-event-kit'
 
 import { filterMessages, filterMessagesByRangeOrPoint } from '../helpers'
 import type { LinterMessage } from '../types'
@@ -72,11 +70,11 @@ export default class PanelDelegate {
         this.update()
       }
     }))
-    this.subscriptions.add(function() {
+    this.subscriptions.add(new Disposable(function() {
       if (changeSubscription) {
         changeSubscription.dispose()
       }
-    })
+    }))
   }
   get filteredMessages(): Array<LinterMessage> {
     let filteredMessages = []

--- a/lib/panel/index.js
+++ b/lib/panel/index.js
@@ -8,7 +8,7 @@ import Delegate from './delegate'
 import Component from './component'
 import type { LinterMessage } from '../types'
 
-export default class Panel {
+class Panel {
   delegate: Delegate;
   subscriptions: CompositeDisposable;
 
@@ -35,3 +35,5 @@ export default class Panel {
     this.subscriptions.dispose()
   }
 }
+
+module.exports = Panel

--- a/lib/panel/index.js
+++ b/lib/panel/index.js
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { CompositeDisposable } from 'sb-event-kit'
+import { CompositeDisposable, Disposable } from 'atom'
 
 import Delegate from './delegate'
 import Component from './component'
@@ -13,20 +13,22 @@ class Panel {
   subscriptions: CompositeDisposable;
 
   constructor() {
+    this.subscriptions = new CompositeDisposable()
+
     const element = document.createElement('div')
     const panel = atom.workspace.addBottomPanel({
       item: element,
       visible: true,
       priority: 500,
     })
+    this.subscriptions.add(new Disposable(function() {
+      panel.destroy()
+    }))
+
     this.delegate = new Delegate(panel)
-    this.subscriptions = new CompositeDisposable()
+    this.subscriptions.add(this.delegate)
 
     ReactDOM.render(<Component delegate={this.delegate} />, element)
-    this.subscriptions.add(function() {
-      panel.destroy()
-    })
-    this.subscriptions.add(this.delegate)
   }
   update(messages: Array<LinterMessage>): void {
     this.delegate.update(messages)

--- a/lib/status-bar/element.js
+++ b/lib/status-bar/element.js
@@ -1,7 +1,7 @@
 /* @flow */
 
-import { CompositeDisposable, Emitter } from 'sb-event-kit'
-import type { Disposable } from 'sb-event-kit'
+import { CompositeDisposable, Emitter } from 'atom'
+import type { Disposable } from 'atom'
 
 export default class Element {
   item: HTMLElement;

--- a/lib/status-bar/index.js
+++ b/lib/status-bar/index.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { CompositeDisposable } from 'sb-event-kit'
+import { CompositeDisposable, Disposable } from 'atom'
 
 import Element from './element'
 import { $file } from '../helpers'
@@ -91,11 +91,11 @@ export default class StatusBar {
         priority: statusBarPosition === 'Left' ? 0 : 1000,
       })
     }))
-    this.subscriptions.add(function() {
+    this.subscriptions.add(new Disposable(function() {
       if (statusBar) {
         statusBar.destroy()
       }
-    })
+    }))
   }
   dispose() {
     this.subscriptions.dispose()

--- a/lib/tooltip/delegate.js
+++ b/lib/tooltip/delegate.js
@@ -1,7 +1,7 @@
 /* @flow */
 
-import { CompositeDisposable, Emitter } from 'sb-event-kit'
-import type { Disposable } from 'sb-event-kit'
+import { CompositeDisposable, Emitter } from 'atom'
+import type { Disposable } from 'atom'
 
 export default class TooltipDelegate {
   emitter: Emitter;

--- a/lib/tooltip/index.js
+++ b/lib/tooltip/index.js
@@ -2,9 +2,8 @@
 
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { CompositeDisposable, Emitter } from 'sb-event-kit'
-import type { Point, TextEditor } from 'atom'
-import type { Disposable } from 'sb-event-kit'
+import { CompositeDisposable, Emitter } from 'atom'
+import type { Disposable, Point, TextEditor } from 'atom'
 
 import Delegate from './delegate'
 import MessageElement from './message'

--- a/lib/tree-view/index.js
+++ b/lib/tree-view/index.js
@@ -6,7 +6,7 @@ import disposableEvent from 'disposable-event'
 import { calculateDecorations } from './helpers'
 import type { LinterMessage, TreeViewHighlight } from '../types'
 
-export default class TreeView {
+class TreeView {
   emitter: Emitter;
   messages: Array<LinterMessage>;
   decorations: Object;
@@ -127,3 +127,5 @@ export default class TreeView {
     return parent.querySelector(`[data-path=${CSS.escape(filePath)}]`)
   }
 }
+
+module.exports = TreeView

--- a/lib/tree-view/index.js
+++ b/lib/tree-view/index.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { CompositeDisposable, Emitter } from 'sb-event-kit'
+import { CompositeDisposable, Emitter } from 'atom'
 import debounce from 'sb-debounce'
 import disposableEvent from 'disposable-event'
 import { calculateDecorations } from './helpers'
@@ -35,9 +35,10 @@ export default class TreeView {
 
     setTimeout(() => {
       const element = TreeView.getElement()
-      if (this.subscriptions.disposed || !element) {
+      if (!element) {
         return
       }
+      // Subscription is only added if the CompositeDisposable hasn't been disposed
       this.subscriptions.add(disposableEvent(element, 'click', debounce(() => {
         this.update()
       })))

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "react-dom": "^15.3.2",
     "react-resizable-box": "^1.8.1",
     "sb-debounce": "^1.0.1",
-    "sb-event-kit": "^3.0.0",
     "sb-react-table": "^1.0.1"
   },
   "devDependencies": {

--- a/spec/.eslintrc.json
+++ b/spec/.eslintrc.json
@@ -1,12 +1,5 @@
 {
-  "globals": {
-    "waitsForPromise": true,
-    "describe": true,
-    "beforeEach": true,
-    "afterEach": true,
-    "jasmine": true,
-    "expect": true,
-    "spyOn": true,
-    "it": true
+  "env": {
+    "jasmine": true
   }
 }


### PR DESCRIPTION
Defer several actions currently being done in package activation till an idle time. The has the effect of pushing the massive requires of React and ReactDOM off to the idle time as the main activation doesn't require them.

On my system on a blank profile (`linter`, `linter-ui-default`, `busy-signal`, `intentions` the only non-core packages) this brings the average "activation" time from 311 ms down to 16.8 ms, or in other words a speed up of ~18.5x. It's possible with a major refactor this could be brought down further, but for now this should be a decent improvement.

Fixes #226.