### PR TITLE
Use Docks API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## Upcoming
 
+* Fix for Nuclide's file tree
 - Add `hidePanelWhenEmpty` config
 - Add `hidePanelUnlessTextEditor` config
 
 ## 1.3.0
 
 * Add docks API support
-* Fix for Nuclide's file tree
 * Remove tooltip if it exists on config change
 * Remove tooltip when cursor changes (only when `tooltipFollows` is set to `Mouse`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Upcoming
+
+- Add `hidePanelWhenEmpty` config
+- Add `hidePanelUnlessTextEditor` config
+
 ## 1.3.0
 
 * Add docks API support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,7 @@
-## Upcoming
-
-* Fix for Nuclide's Tree View
-
 ## 1.3.0
 
 * Add docks API support
+* Fix for Nuclide's file tree
 * Remove tooltip if it exists on config change
 * Remove tooltip when cursor changes (only when `tooltipFollows` is set to `Mouse`)
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -17,6 +17,7 @@ export const severityNames = {
   warning: 'Warning',
   info: 'Info',
 }
+export const WORKSPACE_URI = 'atom://linter-ui-default'
 
 export function $range(message: LinterMessage): ?Object {
   return message.version === 1 ? message.range : message.location.position

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,19 +1,19 @@
 /* @flow */
 
 import { CompositeDisposable } from 'atom'
+import Panel from './panel'
 import Commands from './commands'
 import StatusBar from './status-bar'
 import BusySignal from './busy-signal'
 import Intentions from './intentions'
 import type { Linter, LinterMessage, MessagesPatch } from './types'
 
-let Panel
 let Editors
 let TreeView
 
 class LinterUI {
   name: string;
-  panel: ?Panel;
+  panel: Panel;
   signal: BusySignal;
   editors: ?Editors;
   treeview: TreeView;
@@ -40,18 +40,8 @@ class LinterUI {
 
     const obsShowPanelCB = window.requestIdleCallback(function observeShowPanel() {
       this.idleCallbacks.delete(obsShowPanelCB)
-      if (!Panel) {
-        Panel = require('./panel')
-      }
-      this.subscriptions.add(atom.config.observe('linter-ui-default.showPanel', (showPanel) => {
-        if (showPanel && !this.panel) {
-          this.panel = new Panel()
-          this.panel.update(this.messages)
-        } else if (!showPanel && this.panel) {
-          this.panel.dispose()
-          this.panel = null
-        }
-      }))
+      this.panel = new Panel()
+      this.panel.update(this.messages)
     }.bind(this))
     this.idleCallbacks.add(obsShowPanelCB)
 

--- a/lib/panel/component.js
+++ b/lib/panel/component.js
@@ -12,26 +12,16 @@ class PanelComponent extends React.Component {
   };
   state: {
     messages: Array<LinterMessage>,
-    visibility: boolean,
-    tempHeight: ?number,
   };
   constructor(props: Object, context: ?Object) {
     super(props, context)
     this.state = {
       messages: this.props.delegate.filteredMessages,
-      visibility: this.props.delegate.visibility,
-      tempHeight: null,
     }
   }
   componentDidMount() {
     this.props.delegate.onDidChangeMessages((messages) => {
       this.setState({ messages })
-    })
-    this.props.delegate.onDidChangeVisibility((visibility) => {
-      this.setState({ visibility })
-    })
-    this.props.delegate.onDidChangePanelConfig(() => {
-      this.setState({ tempHeight: null })
     })
   }
   onClick = (e: MouseEvent, row: LinterMessage) => {
@@ -44,12 +34,6 @@ class PanelComponent extends React.Component {
     } else {
       visitMessage(row)
     }
-  }
-  onResize = (direction: 'top', size: { width: number, height: number }) => {
-    this.setState({ tempHeight: size.height })
-  }
-  onResizeStop = (direction: 'top', size: { width: number, height: number }) => {
-    this.props.delegate.updatePanelHeight(size.height)
   }
   render() {
     const { delegate } = this.props
@@ -64,7 +48,6 @@ class PanelComponent extends React.Component {
     }
 
     const customStyle: Object = { overflowY: 'scroll', height: '100%' }
-    // TODO: Panel hides when no messages config?
 
     return (
       <div id="linter-panel" tabIndex="-1" style={customStyle}>

--- a/lib/panel/delegate.js
+++ b/lib/panel/delegate.js
@@ -8,15 +8,14 @@ import type { LinterMessage } from '../types'
 class PanelDelegate {
   emitter: Emitter;
   messages: Array<LinterMessage>;
-  visibility: boolean;
-  panelHeight: number;
+  filteredMessages: Array<LinterMessage>;
   subscriptions: CompositeDisposable;
   panelRepresents: 'Entire Project' | 'Current File' | 'Current Line';
-  panelTakesMinimumHeight: boolean;
 
   constructor() {
     this.emitter = new Emitter()
     this.messages = []
+    this.filteredMessages = []
     this.subscriptions = new CompositeDisposable()
 
     this.subscriptions.add(atom.config.observe('linter-ui-default.panelRepresents', (panelRepresents) => {
@@ -26,30 +25,14 @@ class PanelDelegate {
         this.update()
       }
     }))
-    this.subscriptions.add(atom.config.observe('linter-ui-default.panelHeight', (panelHeight) => {
-      const notInitial = typeof this.panelHeight !== 'undefined'
-      this.panelHeight = panelHeight
-      if (notInitial) {
-        this.emitter.emit('observe-panel-config')
-      }
-    }))
-    this.subscriptions.add(atom.config.observe('linter-ui-default.panelTakesMinimumHeight', (panelTakesMinimumHeight) => {
-      const notInitial = typeof this.panelTakesMinimumHeight !== 'undefined'
-      this.panelTakesMinimumHeight = panelTakesMinimumHeight
-      if (notInitial) {
-        this.emitter.emit('observe-panel-config')
-      }
-    }))
-
     let changeSubscription
     this.subscriptions.add(atom.workspace.observeActivePaneItem((paneItem) => {
       if (changeSubscription) {
         changeSubscription.dispose()
         changeSubscription = null
       }
-      this.visibility = atom.workspace.isTextEditor(paneItem)
-      this.emitter.emit('observe-visibility', this.visibility)
-      if (this.visibility) {
+      const isTextEditor = atom.workspace.isTextEditor(paneItem)
+      if (isTextEditor) {
         if (this.panelRepresents !== 'Entire Project') {
           this.update()
         }
@@ -61,9 +44,8 @@ class PanelDelegate {
           }
         })
       }
-      const shouldUpdate = typeof this.visibility !== 'undefined' && this.panelRepresents !== 'Entire Project'
 
-      if (this.visibility && shouldUpdate) {
+      if (this.panelRepresents !== 'Entire Project' || isTextEditor) {
         this.update()
       }
     }))
@@ -73,7 +55,7 @@ class PanelDelegate {
       }
     }))
   }
-  get filteredMessages(): Array<LinterMessage> {
+  getFilteredMessages(): Array<LinterMessage> {
     let filteredMessages = []
     if (this.panelRepresents === 'Entire Project') {
       filteredMessages = this.messages
@@ -93,19 +75,11 @@ class PanelDelegate {
     if (Array.isArray(messages)) {
       this.messages = messages
     }
+    this.filteredMessages = this.getFilteredMessages()
     this.emitter.emit('observe-messages', this.filteredMessages)
-  }
-  updatePanelHeight(panelHeight: number): void {
-    atom.config.set('linter-ui-default.panelHeight', panelHeight)
   }
   onDidChangeMessages(callback: ((messages: Array<LinterMessage>) => any)): Disposable {
     return this.emitter.on('observe-messages', callback)
-  }
-  onDidChangeVisibility(callback: ((visibility: boolean) => any)): Disposable {
-    return this.emitter.on('observe-visibility', callback)
-  }
-  onDidChangePanelConfig(callback: (() => any)): Disposable {
-    return this.emitter.on('observe-panel-config', callback)
   }
   dispose() {
     this.subscriptions.dispose()

--- a/lib/panel/dock.js
+++ b/lib/panel/dock.js
@@ -15,7 +15,6 @@ class PanelDock {
     this.element = document.createElement('div')
     this.subscriptions = new CompositeDisposable()
     ReactDOM.render(<Component delegate={delegate} />, this.element)
-    // TODO: Focus editor on open
   }
   getURI() {
     return WORKSPACE_URI

--- a/lib/panel/dock.js
+++ b/lib/panel/dock.js
@@ -1,0 +1,43 @@
+/* @flow */
+
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { CompositeDisposable } from 'atom'
+
+import Component from './component'
+import { WORKSPACE_URI } from '../helpers'
+
+class PanelDock {
+  element: HTMLElement;
+  subscriptions: CompositeDisposable;
+
+  constructor(delegate: Object) {
+    this.element = document.createElement('div')
+    this.subscriptions = new CompositeDisposable()
+    ReactDOM.render(<Component delegate={delegate} />, this.element)
+  }
+  getURI() {
+    return WORKSPACE_URI
+  }
+  getTitle() {
+    return 'Linter'
+  }
+  getDefaultLocation() {
+    return 'bottom'
+  }
+  getAllowedLocations() {
+    return ['center', 'bottom', 'top']
+  }
+  getPreferredHeight() {
+    return 100
+  }
+  dispose() {
+    this.subscriptions.dispose()
+    const paneContainer = atom.workspace.paneContainerForItem(this)
+    if (paneContainer) {
+      paneContainer.paneForItem(this).destroyItem(this, true)
+    }
+  }
+}
+
+module.exports = PanelDock

--- a/lib/panel/dock.js
+++ b/lib/panel/dock.js
@@ -15,6 +15,7 @@ class PanelDock {
     this.element = document.createElement('div')
     this.subscriptions = new CompositeDisposable()
     ReactDOM.render(<Component delegate={delegate} />, this.element)
+    // TODO: Focus editor on open
   }
   getURI() {
     return WORKSPACE_URI

--- a/lib/panel/index.js
+++ b/lib/panel/index.js
@@ -1,56 +1,103 @@
 /* @flow */
 
-import React from 'react'
-import ReactDOM from 'react-dom'
 import { CompositeDisposable } from 'atom'
-
+import { WORKSPACE_URI } from '../helpers'
 import Delegate from './delegate'
-import Component from './component'
 import type { LinterMessage } from '../types'
 
+let PanelDock
+
 class Panel {
+  panel: ?PanelDock;
   element: HTMLElement;
   delegate: Delegate;
+  deactivating: boolean;
+  initializing: boolean;
   subscriptions: CompositeDisposable;
-
+  showPanelConfig: boolean;
+  showPanelStatePane: boolean;
+  showPanelStateMessages: boolean;
   constructor() {
-    this.subscriptions = new CompositeDisposable()
-
+    this.panel = null
     this.element = document.createElement('div')
     this.delegate = new Delegate()
+    this.deactivating = false
+    this.initializing = true
+    this.subscriptions = new CompositeDisposable()
+    this.showPanelStateMessages = false
+    this.showPanelStatePane = atom.workspace.isTextEditor(atom.workspace.getActivePaneItem())
+
     this.subscriptions.add(this.delegate)
-
-    ReactDOM.render(<Component delegate={this.delegate} />, this.element)
-
-    atom.workspace.open(this)
-  }
-  getURI() {
-    return 'atom://linter-ui-default'
-  }
-  getTitle() {
-    return 'Linter'
-  }
-  getDefaultLocation() {
-    return 'bottom'
-  }
-  getAllowedLocations() {
-    return ['center', 'bottom', 'top']
+    this.subscriptions.add(atom.workspace.addOpener((uri) => {
+      if (uri === WORKSPACE_URI) {
+        if (this.panel) {
+          this.deactivate()
+        }
+        if (!PanelDock) {
+          PanelDock = require('./dock')
+        }
+        this.panel = new PanelDock(this.delegate)
+        return this.panel
+      }
+      return null
+    }))
+    this.subscriptions.add(atom.workspace.onDidDestroyPaneItem(({ item: paneItem }) => {
+      const uri = paneItem && paneItem.getURI ? paneItem.getURI() : null
+      if (uri === WORKSPACE_URI && !this.deactivating) {
+        atom.config.set('linter-ui-default.showPanel', false)
+      }
+    }))
+    this.subscriptions.add(atom.workspace.onDidStopChangingActivePaneItem((paneItem) => {
+      if (paneItem instanceof PanelDock) {
+        return
+      }
+      this.showPanelStatePane = atom.workspace.isTextEditor(paneItem)
+      this.refresh()
+    }))
+    this.subscriptions.add(atom.config.observe('linter-ui-default.showPanel', (showPanel) => {
+      this.showPanelConfig = showPanel
+      this.refresh()
+    }))
+    this.initializing = false
+    this.refresh()
   }
   update(messages: Array<LinterMessage>): void {
     this.delegate.update(messages)
+    this.showPanelStateMessages = !!this.delegate.filteredMessages.length
+    this.refresh()
   }
-  destroy() {
-    atom.config.set('linter-ui-default.showPanel', false)
+  async refresh() {
+    if (this.initializing) {
+      return
+    }
+    if (
+      (this.showPanelConfig) &&
+      (this.showPanelStatePane) &&
+      (this.showPanelStateMessages)
+    ) {
+      await this.activate()
+    } else {
+      this.deactivate()
+    }
   }
-  getPreferredHeight() {
-    return 100
+  async activate() {
+    if (this.panel) {
+      return
+    }
+    await atom.workspace.open(WORKSPACE_URI)
+  }
+  deactivate() {
+    if (!this.panel) {
+      return
+    }
+    this.deactivating = true
+    this.panel.dispose()
+    this.deactivating = false
+    this.panel = null
   }
   dispose() {
+    this.deactivate()
     this.subscriptions.dispose()
-    const paneContainer = atom.workspace.paneContainerForItem(this)
-    if (paneContainer) {
-      paneContainer.paneForItem(this).destroyItem(this, true)
-    }
   }
 }
 

--- a/lib/panel/index.js
+++ b/lib/panel/index.js
@@ -44,7 +44,14 @@ class Panel {
         if (!PanelDock) {
           PanelDock = require('./dock')
         }
+        const oldPaneItem = atom.workspace.getActivePaneItem()
         this.panel = new PanelDock(this.delegate)
+        // NOTE: Atom has no API to not focus on the newly opened dock item
+        setTimeout(function() {
+          if (oldPaneItem && oldPaneItem.element) {
+            oldPaneItem.element.focus()
+          }
+        }, 200)
         return this.panel
       }
       return null

--- a/lib/panel/index.js
+++ b/lib/panel/index.js
@@ -15,6 +15,8 @@ class Panel {
   initializing: boolean;
   subscriptions: CompositeDisposable;
   showPanelConfig: boolean;
+  hidePanelWhenEmpty: boolean;
+  hidePanelUnlessTextEditor: boolean;
   showPanelStatePane: boolean;
   showPanelStateMessages: boolean;
   constructor() {
@@ -28,6 +30,12 @@ class Panel {
     this.showPanelStatePane = atom.workspace.isTextEditor(atom.workspace.getActivePaneItem())
 
     this.subscriptions.add(this.delegate)
+    this.subscriptions.add(atom.config.observe('linter-ui-default.hidePanelWhenEmpty', (hidePanelWhenEmpty) => {
+      this.hidePanelWhenEmpty = hidePanelWhenEmpty
+    }))
+    this.subscriptions.add(atom.config.observe('linter-ui-default.hidePanelUnlessTextEditor', (hidePanelUnlessTextEditor) => {
+      this.hidePanelUnlessTextEditor = hidePanelUnlessTextEditor
+    }))
     this.subscriptions.add(atom.workspace.addOpener((uri) => {
       if (uri === WORKSPACE_URI) {
         if (this.panel) {
@@ -48,7 +56,7 @@ class Panel {
       }
     }))
     this.subscriptions.add(atom.workspace.onDidStopChangingActivePaneItem((paneItem) => {
-      if (paneItem instanceof PanelDock) {
+      if (PanelDock && paneItem instanceof PanelDock) {
         return
       }
       this.showPanelStatePane = atom.workspace.isTextEditor(paneItem)
@@ -72,8 +80,8 @@ class Panel {
     }
     if (
       (this.showPanelConfig) &&
-      (this.showPanelStatePane) &&
-      (this.showPanelStateMessages)
+      (!this.hidePanelUnlessTextEditor || this.showPanelStatePane) &&
+      (!this.hidePanelWhenEmpty || this.showPanelStateMessages)
     ) {
       await this.activate()
     } else {

--- a/package.json
+++ b/package.json
@@ -95,6 +95,18 @@
       "default": true,
       "order": 1
     },
+    "hidePanelWhenEmpty": {
+      "description": "Hide panel when there are no issues to display",
+      "type": "boolean",
+      "default": true,
+      "order": 1
+    },
+    "hidePanelUnlessTextEditor": {
+      "description": "Hide panel for settings view and other pane items",
+      "type": "boolean",
+      "default": true,
+      "order": 1
+    },
     "decorateOnTreeView": {
       "type": "string",
       "description": "Underline the selected type in TreeView to indicate issues",


### PR DESCRIPTION
Todo:

- [x] Subscribe to when the panel is removed by user interaction and disable the showPanel config
- [x] Have a better way of destroying the panel other than iterating all docks and trying to destroy it in all of them
- [x] Maaaaybe auto-hide the pane container linter is in if config says so? This will get dirty fast, it'll be fine for bottom panes but imagine top/left/right panes