### PR TITLE
Remove hidePanelUnlessTextEditor config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Upcoming
 
+- Remove `hidePanelUnlessTextEditor` config
 - Remove linter tooltip when Text Editor is unfocused
 - Readd `panelHeight` config and make it work on Docks
 - Change status bar to represent Entire Projecy by default

--- a/lib/panel/index.js
+++ b/lib/panel/index.js
@@ -16,8 +16,6 @@ class Panel {
   subscriptions: CompositeDisposable;
   showPanelConfig: boolean;
   hidePanelWhenEmpty: boolean;
-  hidePanelUnlessTextEditor: boolean;
-  showPanelStatePane: boolean;
   showPanelStateMessages: boolean;
   constructor() {
     this.panel = null
@@ -27,15 +25,10 @@ class Panel {
     this.initializing = true
     this.subscriptions = new CompositeDisposable()
     this.showPanelStateMessages = false
-    this.showPanelStatePane = atom.workspace.isTextEditor(atom.workspace.getActivePaneItem())
 
     this.subscriptions.add(this.delegate)
     this.subscriptions.add(atom.config.observe('linter-ui-default.hidePanelWhenEmpty', (hidePanelWhenEmpty) => {
       this.hidePanelWhenEmpty = hidePanelWhenEmpty
-      this.refresh()
-    }))
-    this.subscriptions.add(atom.config.observe('linter-ui-default.hidePanelUnlessTextEditor', (hidePanelUnlessTextEditor) => {
-      this.hidePanelUnlessTextEditor = hidePanelUnlessTextEditor
       this.refresh()
     }))
     this.subscriptions.add(atom.workspace.addOpener((uri) => {
@@ -64,13 +57,6 @@ class Panel {
         atom.config.set('linter-ui-default.showPanel', false)
       }
     }))
-    this.subscriptions.add(atom.workspace.onDidStopChangingActivePaneItem((paneItem) => {
-      if (PanelDock && paneItem instanceof PanelDock) {
-        return
-      }
-      this.showPanelStatePane = atom.workspace.isTextEditor(paneItem)
-      this.refresh()
-    }))
     this.subscriptions.add(atom.config.observe('linter-ui-default.showPanel', (showPanel) => {
       this.showPanelConfig = showPanel
       this.refresh()
@@ -89,7 +75,6 @@ class Panel {
     }
     if (
       (this.showPanelConfig) &&
-      (!this.hidePanelUnlessTextEditor || this.showPanelStatePane) &&
       (!this.hidePanelWhenEmpty || this.showPanelStateMessages)
     ) {
       await this.activate()

--- a/package.json
+++ b/package.json
@@ -101,12 +101,6 @@
       "default": true,
       "order": 1
     },
-    "hidePanelUnlessTextEditor": {
-      "description": "Hide panel for settings view and other pane items",
-      "type": "boolean",
-      "default": true,
-      "order": 1
-    },
     "decorateOnTreeView": {
       "type": "string",
       "description": "Underline the selected type in TreeView to indicate issues",


### PR DESCRIPTION
Unfortunately, monitoring the active pane becomes *very* tricky with the new Docks
Because clicking on another dock makes it a pane item and we have to hide the linter panel when user clicks at say the new github dock.

Removing this behavior seems like the way forward

Fixes #294