### PR TITLE
Remove Editor tooltip when unfocused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming
+
+- Remove linter tooltip when Text Editor is unfocused
+
 ## 1.4.0
 
 * Fix for Nuclide's file tree

--- a/lib/editors.js
+++ b/lib/editors.js
@@ -21,6 +21,13 @@ class Editors {
     this.subscriptions.add(atom.workspace.observeTextEditors((textEditor) => {
       this.getEditor(textEditor)
     }))
+    this.subscriptions.add(atom.workspace.observeActivePaneItem((paneItem) => {
+      this.editors.forEach((editor) => {
+        if (editor.textEditor !== paneItem) {
+          editor.removeTooltip()
+        }
+      })
+    }))
   }
   isFirstRender(): boolean {
     return this.firstRender


### PR DESCRIPTION
Fixes https://github.com/steelbrain/linter-ui-default/issues/225

⚠️   This will also mean that it'll remove tooltip when we click on any other dock even Linter's own ⚠️ 