### PR TITLE
Cleanup dock hiding implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Remove `hidePanelUnlessTextEditor` config
 - Tweak Tooltip visuals (See #301 for Screenshots)
+- Do not focus Linter dock on open (less UI clutter)
 - Remove linter tooltip when Text Editor is unfocused
 - Readd `panelHeight` config and make it work on Docks
 - Replace Linter Status bar with icons instead of boxes

--- a/lib/panel/index.js
+++ b/lib/panel/index.js
@@ -46,10 +46,10 @@ class Panel {
     this.activate()
   }
   async activate() {
-    atom.workspace.open(WORKSPACE_URI, {
+    await atom.workspace.open(WORKSPACE_URI, {
       activatePane: false,
       activateItem: false,
-      searchAllPanes: false,
+      searchAllPanes: true,
     })
   }
   update(messages: Array<LinterMessage>): void {

--- a/lib/panel/index.js
+++ b/lib/panel/index.js
@@ -3,57 +3,37 @@
 import { CompositeDisposable } from 'atom'
 import { WORKSPACE_URI } from '../helpers'
 import Delegate from './delegate'
+import PanelDock from './dock'
 import type { LinterMessage } from '../types'
 
-let PanelDock
-
 class Panel {
-  panel: ?PanelDock;
+  panel: PanelDock;
   element: HTMLElement;
   delegate: Delegate;
-  deactivating: boolean;
-  initializing: boolean;
   subscriptions: CompositeDisposable;
   showPanelConfig: boolean;
   hidePanelWhenEmpty: boolean;
   showPanelStateMessages: boolean;
   constructor() {
-    this.panel = null
     this.element = document.createElement('div')
     this.delegate = new Delegate()
-    this.deactivating = false
-    this.initializing = true
+    this.panel = new PanelDock(this.delegate)
     this.subscriptions = new CompositeDisposable()
     this.showPanelStateMessages = false
 
     this.subscriptions.add(this.delegate)
+    this.subscriptions.add(this.panel)
     this.subscriptions.add(atom.config.observe('linter-ui-default.hidePanelWhenEmpty', (hidePanelWhenEmpty) => {
       this.hidePanelWhenEmpty = hidePanelWhenEmpty
-      this.refresh()
     }))
     this.subscriptions.add(atom.workspace.addOpener((uri) => {
       if (uri === WORKSPACE_URI) {
-        if (this.panel) {
-          this.deactivate()
-        }
-        if (!PanelDock) {
-          PanelDock = require('./dock')
-        }
-        const oldPaneItem = atom.workspace.getActivePaneItem()
-        this.panel = new PanelDock(this.delegate)
-        // NOTE: Atom has no API to not focus on the newly opened dock item
-        setTimeout(function() {
-          if (oldPaneItem && oldPaneItem.element) {
-            oldPaneItem.element.focus()
-          }
-        }, 200)
         return this.panel
       }
       return null
     }))
     this.subscriptions.add(atom.workspace.onDidDestroyPaneItem(({ item: paneItem }) => {
-      const uri = paneItem && paneItem.getURI ? paneItem.getURI() : null
-      if (uri === WORKSPACE_URI && !this.deactivating) {
+      if (paneItem instanceof PanelDock) {
         atom.config.set('linter-ui-default.showPanel', false)
       }
     }))
@@ -61,8 +41,12 @@ class Panel {
       this.showPanelConfig = showPanel
       this.refresh()
     }))
-    this.initializing = false
-    this.refresh()
+
+    atom.workspace.open(WORKSPACE_URI, {
+      activatePane: false,
+      activateItem: false,
+      searchAllPanes: false,
+    })
   }
   update(messages: Array<LinterMessage>): void {
     this.delegate.update(messages)
@@ -70,35 +54,20 @@ class Panel {
     this.refresh()
   }
   async refresh() {
-    if (this.initializing) {
+    const paneContainer = atom.workspace.paneContainerForItem(this.panel)
+    if (!paneContainer && paneContainer !== 'center') {
       return
     }
     if (
       (this.showPanelConfig) &&
       (!this.hidePanelWhenEmpty || this.showPanelStateMessages)
     ) {
-      await this.activate()
+      paneContainer.show()
     } else {
-      this.deactivate()
+      paneContainer.hide()
     }
-  }
-  async activate() {
-    if (this.panel) {
-      return
-    }
-    await atom.workspace.open(WORKSPACE_URI)
-  }
-  deactivate() {
-    if (!this.panel) {
-      return
-    }
-    this.deactivating = true
-    this.panel.dispose()
-    this.deactivating = false
-    this.panel = null
   }
   dispose() {
-    this.deactivate()
     this.subscriptions.dispose()
   }
 }

--- a/lib/panel/index.js
+++ b/lib/panel/index.js
@@ -64,7 +64,7 @@ class Panel {
       } else return
     }
     const paneContainer = atom.workspace.paneContainerForItem(this.panel)
-    if (!paneContainer && paneContainer !== 'center') {
+    if (!paneContainer && paneContainer === 'bottom') {
       return
     }
     if (

--- a/lib/panel/index.js
+++ b/lib/panel/index.js
@@ -7,7 +7,7 @@ import PanelDock from './dock'
 import type { LinterMessage } from '../types'
 
 class Panel {
-  panel: PanelDock;
+  panel: ?PanelDock;
   element: HTMLElement;
   delegate: Delegate;
   subscriptions: CompositeDisposable;
@@ -25,6 +25,7 @@ class Panel {
     this.subscriptions.add(this.panel)
     this.subscriptions.add(atom.config.observe('linter-ui-default.hidePanelWhenEmpty', (hidePanelWhenEmpty) => {
       this.hidePanelWhenEmpty = hidePanelWhenEmpty
+      this.refresh()
     }))
     this.subscriptions.add(atom.workspace.addOpener((uri) => {
       if (uri === WORKSPACE_URI) {
@@ -34,6 +35,7 @@ class Panel {
     }))
     this.subscriptions.add(atom.workspace.onDidDestroyPaneItem(({ item: paneItem }) => {
       if (paneItem instanceof PanelDock) {
+        this.panel = null
         atom.config.set('linter-ui-default.showPanel', false)
       }
     }))
@@ -41,7 +43,9 @@ class Panel {
       this.showPanelConfig = showPanel
       this.refresh()
     }))
-
+    this.activate()
+  }
+  async activate() {
     atom.workspace.open(WORKSPACE_URI, {
       activatePane: false,
       activateItem: false,
@@ -54,6 +58,11 @@ class Panel {
     this.refresh()
   }
   async refresh() {
+    if (this.panel === null) {
+      if (this.showPanelConfig) {
+        await this.activate()
+      } else return
+    }
     const paneContainer = atom.workspace.paneContainerForItem(this.panel)
     if (!paneContainer && paneContainer !== 'center') {
       return


### PR DESCRIPTION
Previously we were destroying and re-creating a pane item for Linter on hide/show config change

That was messy because it would focus the linter dock each time it would open, tho we were refocusing the text editor it would still make the UI feel laggy and wasn't the best ever experience

Now what we're doing is that we're telling Atom to open it in a pane container, and do not focus the Item or the pane container, and then we're showing the pane container ourselves without focusing it

This makes sure that the ui indicators are the bottom are not hidden then shown because there's no switch of Active Pane Item