### PR TITLE
Fix tooltips background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming
+
+* Use another color variable tooltip background
+
 ## 1.5.4
 
 * Fix the last of known Linter Panel bugs

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -17,7 +17,7 @@
   .message-with-severity(@color) {
     color: @text-color;
     border-left: 8px solid @color;
-    background-color: @background-color-highlight;
+    background-color: @overlay-background-color;
     &:last-child::before {
       border-color: transparent transparent @color @color;
     }

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -17,7 +17,7 @@
   .message-with-severity(@color) {
     color: @text-color;
     border-left: 8px solid @color;
-    background-color: @overlay-background-color;
+    background-color: @inset-panel-background-color;
     &:last-child::before {
       border-color: transparent transparent @color @color;
     }

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -16,6 +16,7 @@
 
   .message-with-severity(@color) {
     color: @text-color;
+    border: 1px solid fade(contrast(@inset-panel-background-color), 5%);
     border-left: 8px solid @color;
     background-color: @inset-panel-background-color;
     &:last-child::before {


### PR DESCRIPTION
Too many themes had the previous color variable as transparent

Atom Dark
<img width="292" alt="screen shot 2017-05-20 at 8 24 50 pm" src="https://cloud.githubusercontent.com/assets/4278113/26276890/a3b9cad0-3d9a-11e7-9de2-831c6a61576e.png">

Atom Light
<img width="291" alt="screen shot 2017-05-20 at 8 24 59 pm" src="https://cloud.githubusercontent.com/assets/4278113/26276892/a9007732-3d9a-11e7-91ad-6889d0b03b91.png">

Atom Material
<img width="302" alt="screen shot 2017-05-20 at 8 27 05 pm" src="https://cloud.githubusercontent.com/assets/4278113/26276898/b5dd9b60-3d9a-11e7-80b9-1d726381c7b6.png">

Nord Atom
<img width="306" alt="screen shot 2017-05-20 at 8 27 23 pm" src="https://cloud.githubusercontent.com/assets/4278113/26276901/c1ce7278-3d9a-11e7-90e8-3f2d60e62092.png">

One Dark
<img width="288" alt="screen shot 2017-05-20 at 8 27 53 pm" src="https://cloud.githubusercontent.com/assets/4278113/26276905/d8c8115a-3d9a-11e7-9cdf-61348e4ea1ef.png">

One Light
<img width="283" alt="screen shot 2017-05-20 at 8 28 27 pm" src="https://cloud.githubusercontent.com/assets/4278113/26276908/e9ff5ad2-3d9a-11e7-97a3-ba670570a987.png">

Apex
<img width="271" alt="screen shot 2017-05-20 at 8 29 01 pm" src="https://cloud.githubusercontent.com/assets/4278113/26276911/fcbf19fa-3d9a-11e7-9d9d-4acfe9919510.png">

