### PR TITLE
Fix tooltip border for multiple messages

### DIFF
--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -16,9 +16,17 @@
 
   .message-with-severity(@color) {
     color: @text-color;
-    border: 1px solid fade(contrast(@inset-panel-background-color), 5%);
-    border-left: 8px solid @color;
     background-color: @inset-panel-background-color;
+
+    border-left: 8px solid @color;
+    border-right: 1px solid fade(contrast(@inset-panel-background-color), 5%);
+    &:first-child {
+      border-top: 1px solid fade(contrast(@inset-panel-background-color), 5%);
+    }
+    &:last-child {
+      border-bottom: 1px solid fade(contrast(@inset-panel-background-color), 5%);
+    }
+
     &:last-child::before {
       border-color: transparent transparent @color @color;
     }


### PR DESCRIPTION
Before
<img width="485" alt="screen shot 2017-05-22 at 1 47 24 am" src="https://cloud.githubusercontent.com/assets/4278113/26287351/062a55e2-3e93-11e7-9ff3-e4d7e06dd545.png">

After
<img width="450" alt="screen shot 2017-05-22 at 2 04 01 am" src="https://cloud.githubusercontent.com/assets/4278113/26287352/0f0c5bd8-3e93-11e7-857f-2aed45dc7ada.png">

