### PR TITLE
allow links in markdown that opens a file in atom

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -77,6 +77,16 @@ export function filterMessagesByRangeOrPoint(messages: Set<LinterMessage> | Arra
   return filtered
 }
 
+export function openFile(file: string, position: ?Point) {
+  const options = {}
+  options.searchAllPanes = true
+  if (position) {
+    options.initialLine = position.row
+    options.initialColumn = position.column
+  }
+  atom.workspace.open(file, options)
+}
+
 export function visitMessage(message: LinterMessage, reference: boolean = false) {
   let messageFile
   let messagePosition
@@ -98,12 +108,9 @@ export function visitMessage(message: LinterMessage, reference: boolean = false)
       messagePosition = messageRange.start
     }
   }
-  atom.workspace.open(messageFile, { searchAllPanes: true }).then(function() {
-    const textEditor = atom.workspace.getActiveTextEditor()
-    if (messagePosition && textEditor && textEditor.getPath() === messageFile) {
-      textEditor.setCursorBufferPosition(messagePosition)
-    }
-  })
+  if (messageFile) {
+    openFile(messageFile, messagePosition)
+  }
 }
 
 export function openExternally(message: LinterMessage): void {

--- a/lib/tooltip/message.js
+++ b/lib/tooltip/message.js
@@ -1,11 +1,22 @@
 /* @flow */
 
+import * as url from 'url'
 import React from 'react'
 import marked from 'marked'
 
-import { visitMessage, openExternally } from '../helpers'
+import { visitMessage, openExternally, openFile } from '../helpers'
 import type TooltipDelegate from './delegate'
 import type { Message } from '../types'
+
+function findHref(el: ?Element): ?string {
+  while (el && !el.classList.contains('linter-line')) {
+    if (el instanceof HTMLAnchorElement) {
+      return el.href
+    }
+    el = el.parentElement
+  }
+  return null
+}
 
 class MessageElement extends React.Component {
   props: {
@@ -71,10 +82,27 @@ class MessageElement extends React.Component {
       console.error('[Linter] Invalid description detected, expected string or function but got:', typeof description)
     }
   }
+  openFile = (ev: Event) => {
+    if (!(ev.target instanceof HTMLElement)) {
+      return
+    }
+    const href = findHref(ev.target)
+    if (!href) {
+      return
+    }
+    // parse the link. e.g. atom://linter/<file>?row=<number>&column=<number>
+    const { protocol, hostname, pathname, query } = url.parse(href, true)
+    if (protocol !== 'atom:' || hostname !== 'linter' || !pathname) {
+      return
+    }
+    const row = query && query.row ? parseInt(query.row, 10) : 0
+    const column = query && query.column ? parseInt(query.column, 10) : 0
+    openFile(pathname.substr(1), { row, column })
+  }
   render() {
     const { message, delegate } = this.props
 
-    return (<linter-message class={message.severity}>
+    return (<linter-message class={message.severity} onClick={this.openFile}>
       { message.description && (
         <a href="#" onClick={() => this.toggleDescription()}>
           <span className={`icon linter-icon icon-${this.state.descriptionShow ? 'chevron-down' : 'chevron-right'}`} />

--- a/lib/tooltip/message.js
+++ b/lib/tooltip/message.js
@@ -90,14 +90,15 @@ class MessageElement extends React.Component {
     if (!href) {
       return
     }
-    // parse the link. e.g. atom://linter/<file>?row=<number>&column=<number>
-    const { protocol, hostname, pathname, query } = url.parse(href, true)
-    if (protocol !== 'atom:' || hostname !== 'linter' || !pathname) {
+    // parse the link. e.g. atom://linter?file=<path>&row=<number>&column=<number>
+    const { protocol, hostname, query } = url.parse(href, true)
+    const file = query && query.file
+    if (protocol !== 'atom:' || hostname !== 'linter' || !file) {
       return
     }
     const row = query && query.row ? parseInt(query.row, 10) : 0
     const column = query && query.column ? parseInt(query.column, 10) : 0
-    openFile(pathname.substr(1), { row, column })
+    openFile(file, { row, column })
   }
   render() {
     const { message, delegate } = this.props


### PR DESCRIPTION
the url of these links have to look like `atom://linter/<file>?row=<number>&column=<number>` where
* `file` is the absolute path to the file
* `row` and `column` are optional and will jump to this position in the editor

Required by: https://github.com/steelbrain/flow-ide/pull/94