### PR TITLE
Fix bug: linter Panel is not clickable

### DIFF
--- a/lib/panel/delegate.js
+++ b/lib/panel/delegate.js
@@ -61,7 +61,7 @@ class PanelDelegate {
       filteredMessages = this.messages
     } else if (this.panelRepresents === 'Current File') {
       const activeEditor = atom.workspace.getActiveTextEditor()
-      if (!activeEditor) return []
+      if (!activeEditor) return this.filteredMessages
       filteredMessages = filterMessages(this.messages, activeEditor.getPath())
     } else if (this.panelRepresents === 'Current Line') {
       const activeEditor = atom.workspace.getActiveTextEditor()


### PR DESCRIPTION
When `panelRepresents` set to `Current File`, linter panel is not clickable because panel is cleaned with `filteredMessages` in delegate. 