### PR TITLE
Show provider times individually

### DIFF
--- a/lib/busy-signal.js
+++ b/lib/busy-signal.js
@@ -9,11 +9,13 @@ class BusySignal {
     linter: Linter,
     filePath: ?string,
   }>;
+  providerTitles: Set<string>;
   useBusySignal: boolean;
   subscriptions: CompositeDisposable;
 
   constructor() {
     this.executing = new Set()
+    this.providerTitles = new Set()
     this.subscriptions = new CompositeDisposable()
 
     this.subscriptions.add(atom.config.observe('linter-ui-default.useBusySignal', (useBusySignal) => {
@@ -27,9 +29,9 @@ class BusySignal {
   update() {
     const provider = this.provider
     if (!provider) return
-    provider.clear()
     if (!this.useBusySignal) return
     const fileMap: Map<?string, Array<string>> = new Map()
+    const currentTitles = new Set()
 
     for (const { filePath, linter } of this.executing) {
       let names = fileMap.get(filePath)
@@ -41,8 +43,25 @@ class BusySignal {
 
     for (const [filePath, names] of fileMap) {
       const path = filePath ? ` on ${atom.project.relativizePath(filePath)[1]}` : ''
-      provider.add(`${names.join(', ')}${path}`)
+      names.forEach((name) => {
+        const title = `${name}${path}`
+        currentTitles.add(title)
+        if (!this.providerTitles.has(title)) {
+          // Add the title since it hasn't been seen before
+          this.providerTitles.add(title)
+          provider.add(title)
+        }
+      })
     }
+
+    // Remove any titles no longer active
+    this.providerTitles.forEach((title) => {
+      if (!currentTitles.has(title)) {
+        provider.remove(title)
+        this.providerTitles.delete(title)
+      }
+    })
+
     fileMap.clear()
   }
   getExecuting(linter: Linter, filePath: ?string): ?Object {
@@ -71,6 +90,7 @@ class BusySignal {
     if (this.provider) {
       this.provider.clear()
     }
+    this.providerTitles.clear()
     this.executing.clear()
     this.subscriptions.dispose()
   }

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -11,9 +11,9 @@ export function getMessage(type: ?string = 'Error', filePath: ?string, range: ?O
   return message
 }
 
-export function getLinter(): Object {
+export function getLinter(name: ?string = 'some'): Object {
   return {
-    name: 'some',
+    name,
     grammarScopes: [],
     lint() {},
   }


### PR DESCRIPTION
Split the timing data for providers out into individual items so they are no longer grouped together randomly.

Fixes https://github.com/steelbrain/linter/issues/1442.