### PR TITLE
Position the gutter marker in the middle

### DIFF
--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -136,6 +136,7 @@ atom-text-editor.editor .linter-highlight, .linter-highlight {
 }
 .linter-gutter.icon::before {
   width: 100%;
+  margin-right: 0px;
   font-size: 1em;
 }
 


### PR DESCRIPTION
In the latest version (at the time of posting) the gutter markers are showing and working. There is only one problem I noticed. This may be a little picky but the marker isn't in the middle of its column. This is a simple fix with a single css addition.
#
Before the change:
![before_change](https://user-images.githubusercontent.com/16006944/29124640-bf6aad76-7d19-11e7-8f59-80c1bc685654.png)
After the change:
![after_change](https://user-images.githubusercontent.com/16006944/29124659-ca2d9458-7d19-11e7-8d76-a932a1d38ede.png)
#
Version tested on:
````
Atom    : 1.21.0-dev-98296bf 
Electron: 1.6.9
Chrome  : 56.0.2924.87
Node    : 7.4.0
````