### PR TITLE
Fix race condition where tooltip would cover autocomplete

### DIFF
--- a/lib/editor/index.js
+++ b/lib/editor/index.js
@@ -81,13 +81,23 @@ class Editor {
     this.subscriptions.add(new Disposable(function() {
       tooltipSubscription.dispose()
     }))
-    this.subscriptions.add(textEditor.onDidChangeCursorPosition(() => {
-      this.ignoreTooltipInvocation = false
+
+    const lastCursorPositions = new WeakMap()
+    this.subscriptions.add(textEditor.onDidChangeCursorPosition(({ cursor, newBufferPosition }) => {
+      const lastBufferPosition = lastCursorPositions.get(cursor)
+      if (!lastBufferPosition || !lastBufferPosition.isEqual(newBufferPosition)) {
+        lastCursorPositions.set(cursor, newBufferPosition)
+        this.ignoreTooltipInvocation = false
+      }
       if (this.tooltipFollows === 'Mouse') {
         this.removeTooltip()
       }
     }))
     this.subscriptions.add(textEditor.getBuffer().onDidChangeText(() => {
+      const cursors = textEditor.getCursors()
+      cursors.forEach((cursor) => {
+        lastCursorPositions.set(cursor, cursor.getBufferPosition())
+      })
       if (this.tooltipFollows !== 'Mouse') {
         this.ignoreTooltipInvocation = true
         this.removeTooltip()


### PR DESCRIPTION
Fixes https://github.com/steelbrain/linter-ui-default/issues/415

Removed the debounce because it's keyboard and not mouse, debounce is not necessary, the operation is sync but happens very quickly so is unnoticable