### PR TITLE
Utilize the new text decoration style

### DIFF
--- a/lib/editor/index.js
+++ b/lib/editor/index.js
@@ -288,7 +288,7 @@ class Editor {
   decorateMarker(message: LinterMessage, marker: Object, paint: 'gutter' | 'editor' | 'both' = 'both') {
     if (paint === 'both' || paint === 'editor') {
       this.textEditor.decorateMarker(marker, {
-        type: 'highlight',
+        type: 'text',
         class: `linter-highlight linter-${message.severity}`,
       })
     }
@@ -296,7 +296,7 @@ class Editor {
     const gutter = this.gutter
     if (gutter && (paint === 'both' || paint === 'gutter')) {
       const element = document.createElement('span')
-      element.className = `linter-gutter linter-highlight linter-${message.severity} icon icon-${message.icon || 'primitive-dot'}`
+      element.className = `linter-gutter linter-gutter-${message.severity} icon icon-${message.icon || 'primitive-dot'}`
       gutter.decorateMarker(marker, {
         class: 'linter-row',
         item: element,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "repository": "https://github.com/steelbrain/linter-ui-default",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.17.0 <2.0.0"
+    "atom": ">=1.19.0 <2.0.0"
   },
   "scripts": {
     "test": "(apm test) && (flow check) && (eslint . )"

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -92,26 +92,34 @@ atom-text-editor.editor .linter-row {
   justify-content: center;
 }
 
-atom-text-editor.editor .linter-highlight, .linter-highlight {
+.linter-gutter {
   .error_type(@color, @priority) {
-    .region {
-      .wavy_border(@color);
-    }
-    &.linter-gutter {
-      color: @color;
-      z-index: @priority;
-    }
+    color: @color;
+    z-index: @priority;
   }
-  &.linter-info {
+  &.linter-gutter-info {
     .error_type(@background-color-info, -1);
   }
-  &.linter-warning {
+  &.linter-gutter-warning {
     .error_type(@background-color-warning, 0);
   }
-  &.linter-error {
+  &.linter-gutter-error {
     .error_type(@background-color-error, 1);
   }
 }
+
+atom-text-editor.editor .linter-highlight, .linter-highlight {
+  &.linter-info {
+    .wavy_border(@background-color-info);
+  }
+  &.linter-warning {
+    .wavy_border(@background-color-warning);
+  }
+  &.linter-error {
+    .wavy_border(@background-color-error);
+  }
+}
+
 .tree-view {
   span.name {
     position: relative;


### PR DESCRIPTION
Use the new `text` decoration style introduced in Atom v1.19.0 in order to properly decorate the text of a range as the old `highlight` style was actually a fluke that it was working at all.

Before:
![image](https://user-images.githubusercontent.com/427137/30071763-dbea248c-921c-11e7-96a4-b100432a980b.png)
_Note the gap in the blank highlighted area._

After:
![image](https://user-images.githubusercontent.com/427137/30071785-f338b716-921c-11e7-81e7-d02c114d4588.png)

Suggested by @as-cii in https://github.com/atom/atom/issues/15508#issuecomment-327130261.