### PR TITLE
Fixed icons misaligned with and below the baseline

### DIFF
--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -154,7 +154,7 @@ atom-text-editor.editor .linter-highlight, .linter-highlight {
   }
   span.icon::before {
     font-size: 12px;
-    vertical-align: middle;
+    vertical-align: baseline;
   }
   &.hide-config, &.hide-pane {
     display: none;


### PR DESCRIPTION
Fixed icons that are vertically misaligned:

Issue:
![icons](https://user-images.githubusercontent.com/460323/30495967-07ef0d48-9a1c-11e7-94d9-b297b5c8e362.png)

Resolved:

![resolved](https://user-images.githubusercontent.com/460323/30496079-5ac7a340-9a1c-11e7-8e90-c3d7081206ce.png)

