### PR TITLE
Simplify and fix alignment of status bar icons

### DIFF
--- a/lib/status-bar/element.js
+++ b/lib/status-bar/element.js
@@ -48,9 +48,9 @@ class Element {
     }
   }
   update(countErrors: number, countWarnings: number, countInfos: number): void {
-    this.itemErrors.childNodes[1].textContent = String(countErrors)
-    this.itemWarnings.childNodes[1].textContent = String(countWarnings)
-    this.itemInfos.childNodes[1].textContent = String(countInfos)
+    this.itemErrors.childNodes[0].textContent = String(countErrors)
+    this.itemWarnings.childNodes[0].textContent = String(countWarnings)
+    this.itemInfos.childNodes[0].textContent = String(countInfos)
 
     if (countErrors) {
       this.itemErrors.classList.add('text-error')

--- a/lib/status-bar/helpers.js
+++ b/lib/status-bar/helpers.js
@@ -3,12 +3,9 @@
 // eslint-disable-next-line import/prefer-default-export
 export function getElement(icon: string): HTMLElement {
   const element = document.createElement('a')
-  const iconElement = document.createElement('span')
 
-  iconElement.classList.add('icon')
-  iconElement.classList.add(`icon-${icon}`)
+  element.classList.add(`icon-${icon}`)
 
-  element.appendChild(iconElement)
   element.appendChild(document.createTextNode(''))
 
   return element

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -152,9 +152,8 @@ atom-text-editor.editor .linter-highlight, .linter-highlight {
   a {
     padding: 2px;
   }
-  span.icon::before {
+  a::before {
     font-size: 12px;
-    vertical-align: middle;
   }
   &.hide-config, &.hide-pane {
     display: none;


### PR DESCRIPTION
Simplify how the status bar icons are being generated, bringing them inline with how other status bar "widgets" are using similar icons.

Examples:

UI | Syntax | Result
-- | ------ | ------
One Dark | One Dark | ![image](https://user-images.githubusercontent.com/427137/30496763-4a4abf46-9a05-11e7-9f00-e7dfb70dc8e2.png)
One Light | One Light | ![image](https://user-images.githubusercontent.com/427137/30496805-6e931970-9a05-11e7-84eb-5411c8509a1a.png)
Atom Material | One Dark | ![image](https://user-images.githubusercontent.com/427137/30496887-ab4c72e4-9a05-11e7-8bd0-a0e3a9149736.png)
Atom Material | One Light | ![image](https://user-images.githubusercontent.com/427137/30496848-8f2171a0-9a05-11e7-89eb-d4adb37c7dc7.png)

Fixes #437.
Closes #438.