### PR TITLE
Set max-width for linter tooltip for readability.

### DIFF
--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -13,7 +13,7 @@
 
 #linter-tooltip {
   margin-top: 3px;
-  max-width: 35em;
+  max-width: 64em;
 
   .message-with-severity(@color) {
     color: @text-color;

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -13,6 +13,7 @@
 
 #linter-tooltip {
   margin-top: 3px;
+  max-width: 35em;
 
   .message-with-severity(@color) {
     color: @text-color;


### PR DESCRIPTION
Line length based off this article, which suggests 21em-30em for readability. Added a few ems just in case.
http://maxdesign.com.au/articles/ideal-line-length-in-ems/
