### PR TITLE
Don't overflow text in linter-tooltip

### DIFF
--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -14,6 +14,7 @@
 #linter-tooltip {
   margin-top: 3px;
   max-width: 64em;
+  overflow: hidden;
 
   .message-with-severity(@color) {
     color: @text-color;


### PR DESCRIPTION
Text is currently allowed to overflow out of the linter tooltip. This has always been case, but with #467 and a custom stylesheet of mine that makes the unexpanded part one line (with `white-space: nowrap`), overflowing can actually happen.

![image](https://user-images.githubusercontent.com/1570168/35707686-9a184e4a-075f-11e8-8bd9-70f0b8b47cd8.png)

This PR hides the overflow.