### PR TITLE
Add alwaysTakeMinimumSpace to new dock panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 * Add a max-width to linter toolip
-* Readd `alwaysTakeMinimumSpace` config which works with Atom Docks!
+* Re-add `alwaysTakeMinimumSpace` config which works with Atom Docks!
 
 ## 1.6.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 1.6.12
+## Upcoming
 
 * Add a max-width to linter toolip
+* Readd `alwaysTakeMinimumSpace` config which works with Atom Docks!
 
 ## 1.6.11
 

--- a/lib/panel/dock.js
+++ b/lib/panel/dock.js
@@ -23,11 +23,13 @@ class PanelDock {
   subscriptions: CompositeDisposable;
   panelHeight: number;
   alwaysTakeMinimumSpace: boolean;
+  lastSetPaneHeight: number | null
 
   constructor(delegate: Object) {
     this.element = document.createElement('div')
     this.subscriptions = new CompositeDisposable()
 
+    this.lastSetPaneHeight = null
     this.subscriptions.add(atom.config.observe('linter-ui-default.panelHeight', (panelHeight) => {
       const changed = typeof this.panelHeight === 'number'
       this.panelHeight = panelHeight
@@ -57,7 +59,7 @@ class PanelDock {
     const paneContainer = getPaneContainer(this)
     let minimumHeight: number | null = null
     const paneContainerView = atom.views.getView(paneContainer)
-    if (paneContainerView) {
+    if (paneContainerView && !this.alwaysTakeMinimumSpace) {
       // NOTE: Super horrible hack but the only possible way I could find :((
       const dockNamesElement = paneContainerView.querySelector('.list-inline.tab-bar.inset-panel')
       const dockNamesRects = dockNamesElement ? dockNamesElement.getClientRects()[0] : null
@@ -69,9 +71,20 @@ class PanelDock {
     }
 
     if (paneContainer) {
+      let updateConfigHeight: number | null = null
       const heightSet = minimumHeight !== null && !forConfigHeight ? Math.min(minimumHeight, this.panelHeight) : this.panelHeight
+
+      // Person resized the panel, save new resized value to config
+      if (this.lastSetPaneHeight !== null && paneContainer.state.size !== this.lastSetPaneHeight) {
+        updateConfigHeight = paneContainer.state.size
+      }
+
       paneContainer.state.size = heightSet
       paneContainer.render(paneContainer.state)
+
+      if (updateConfigHeight !== null) {
+        atom.config.set('linter-ui-default.panelHeight', updateConfigHeight)
+      }
     }
   }
   getURI() {

--- a/lib/panel/dock.js
+++ b/lib/panel/dock.js
@@ -59,7 +59,7 @@ class PanelDock {
     const paneContainer = getPaneContainer(this)
     let minimumHeight: number | null = null
     const paneContainerView = atom.views.getView(paneContainer)
-    if (paneContainerView && !this.alwaysTakeMinimumSpace) {
+    if (paneContainerView && this.alwaysTakeMinimumSpace) {
       // NOTE: Super horrible hack but the only possible way I could find :((
       const dockNamesElement = paneContainerView.querySelector('.list-inline.tab-bar.inset-panel')
       const dockNamesRects = dockNamesElement ? dockNamesElement.getClientRects()[0] : null

--- a/lib/panel/dock.js
+++ b/lib/panel/dock.js
@@ -106,7 +106,7 @@ class PanelDock {
   dispose() {
     this.subscriptions.dispose()
     const paneContainer = getPaneContainer(this)
-    if (paneContainer && !this.alwaysTakeMinimumSpace) {
+    if (paneContainer && !this.alwaysTakeMinimumSpace && paneContainer.state.size !== this.panelHeight) {
       atom.config.set('linter-ui-default.panelHeight', paneContainer.state.size)
       paneContainer.paneForItem(this).destroyItem(this, true)
     }

--- a/lib/panel/dock.js
+++ b/lib/panel/dock.js
@@ -79,6 +79,7 @@ class PanelDock {
         updateConfigHeight = paneContainer.state.size
       }
 
+      this.lastSetPaneHeight = heightSet
       paneContainer.state.size = heightSet
       paneContainer.render(paneContainer.state)
 

--- a/lib/panel/dock.js
+++ b/lib/panel/dock.js
@@ -7,6 +7,17 @@ let React
 let ReactDOM
 let Component
 
+// eslint-disable-next-line no-use-before-define
+function getPaneContainer(item: PanelDock) {
+  const paneContainer = atom.workspace.paneContainerForItem(item)
+  // NOTE: This is an internal API access
+  // It's necessary because there's no Public API for it yet
+  if (paneContainer && typeof paneContainer.state === 'object' && typeof paneContainer.state.size === 'number' && typeof paneContainer.render === 'function') {
+    return paneContainer
+  }
+  return null
+}
+
 class PanelDock {
   element: HTMLElement;
   subscriptions: CompositeDisposable;
@@ -15,10 +26,8 @@ class PanelDock {
     this.element = document.createElement('div')
     this.subscriptions = new CompositeDisposable()
     this.subscriptions.add(atom.config.observe('linter-ui-default.panelHeight', (panelHeight) => {
-      const paneContainer = atom.workspace.paneContainerForItem(this)
-      // NOTE: This is an internal API access
-      // It's necessary because there's no Public API for it yet
-      if (paneContainer && typeof paneContainer.state === 'object' && typeof paneContainer.state.size === 'number' && typeof paneContainer.render === 'function') {
+      const paneContainer = getPaneContainer(this)
+      if (paneContainer) {
         paneContainer.state.size = panelHeight
         paneContainer.render(paneContainer.state)
       }
@@ -53,11 +62,9 @@ class PanelDock {
   }
   dispose() {
     this.subscriptions.dispose()
-    const paneContainer = atom.workspace.paneContainerForItem(this)
+    const paneContainer = getPaneContainer(this)
     if (paneContainer) {
-      if (typeof paneContainer.state === 'object' && typeof paneContainer.state.size === 'number') {
-        atom.config.set('linter-ui-default.panelHeight', paneContainer.state.size)
-      }
+      atom.config.set('linter-ui-default.panelHeight', paneContainer.state.size)
       paneContainer.paneForItem(this).destroyItem(this, true)
     }
   }

--- a/lib/panel/dock.js
+++ b/lib/panel/dock.js
@@ -75,7 +75,7 @@ class PanelDock {
       const heightSet = minimumHeight !== null && !forConfigHeight ? Math.min(minimumHeight, this.panelHeight) : this.panelHeight
 
       // Person resized the panel, save new resized value to config
-      if (this.lastSetPaneHeight !== null && paneContainer.state.size !== this.lastSetPaneHeight) {
+      if (this.lastSetPaneHeight !== null && paneContainer.state.size !== this.lastSetPaneHeight && !forConfigHeight) {
         updateConfigHeight = paneContainer.state.size
       }
 

--- a/lib/panel/dock.js
+++ b/lib/panel/dock.js
@@ -21,17 +21,24 @@ function getPaneContainer(item: PanelDock) {
 class PanelDock {
   element: HTMLElement;
   subscriptions: CompositeDisposable;
+  panelHeight: number;
+  alwaysTakeMinimumSpace: boolean;
 
   constructor(delegate: Object) {
     this.element = document.createElement('div')
     this.subscriptions = new CompositeDisposable()
+
     this.subscriptions.add(atom.config.observe('linter-ui-default.panelHeight', (panelHeight) => {
-      const paneContainer = getPaneContainer(this)
-      if (paneContainer) {
-        paneContainer.state.size = panelHeight
-        paneContainer.render(paneContainer.state)
+      const changed = typeof this.panelHeight === 'number'
+      this.panelHeight = panelHeight
+      if (changed) {
+        this.doPanelResize(true)
       }
     }))
+    this.subscriptions.add(atom.config.observe('linter-ui-default.alwaysTakeMinimumSpace', (alwaysTakeMinimumSpace) => {
+      this.alwaysTakeMinimumSpace = alwaysTakeMinimumSpace
+    }))
+    this.doPanelResize()
 
     if (!React) {
       React = require('react')
@@ -44,6 +51,28 @@ class PanelDock {
     }
 
     ReactDOM.render(<Component delegate={delegate} />, this.element)
+  }
+  // NOTE: Chose a name that won't conflict with Dock APIs
+  doPanelResize(forConfigHeight: boolean = false) {
+    const paneContainer = getPaneContainer(this)
+    let minimumHeight: number | null = null
+    const paneContainerView = atom.views.getView(paneContainer)
+    if (paneContainerView) {
+      // NOTE: Super horrible hack but the only possible way I could find :((
+      const dockNamesElement = paneContainerView.querySelector('.list-inline.tab-bar.inset-panel')
+      const dockNamesRects = dockNamesElement ? dockNamesElement.getClientRects()[0] : null
+      const tableElement = this.element.querySelector('table')
+      const panelRects = tableElement ? tableElement.getClientRects()[0] : null
+      if (dockNamesRects && panelRects) {
+        minimumHeight = dockNamesRects.height + panelRects.height + 1
+      }
+    }
+
+    if (paneContainer) {
+      const heightSet = minimumHeight !== null && !forConfigHeight ? Math.min(minimumHeight, this.panelHeight) : this.panelHeight
+      paneContainer.state.size = heightSet
+      paneContainer.render(paneContainer.state)
+    }
   }
   getURI() {
     return WORKSPACE_URI
@@ -63,7 +92,7 @@ class PanelDock {
   dispose() {
     this.subscriptions.dispose()
     const paneContainer = getPaneContainer(this)
-    if (paneContainer) {
+    if (paneContainer && !this.alwaysTakeMinimumSpace) {
       atom.config.set('linter-ui-default.panelHeight', paneContainer.state.size)
       paneContainer.paneForItem(this).destroyItem(this, true)
     }

--- a/lib/panel/index.js
+++ b/lib/panel/index.js
@@ -6,7 +6,7 @@ import PanelDock from './dock'
 import type { LinterMessage } from '../types'
 
 class Panel {
-  panel: ?PanelDock;
+  panel: PanelDock | null;
   element: HTMLElement;
   delegate: Delegate;
   messages: Array<LinterMessage>;
@@ -70,14 +70,15 @@ class Panel {
     this.refresh()
   }
   async refresh() {
-    if (this.panel === null) {
+    const panel = this.panel
+    if (panel === null) {
       if (this.showPanelConfig) {
         await this.activate()
       }
       return
     }
-    const paneContainer = atom.workspace.paneContainerForItem(this.panel)
-    if (!paneContainer || paneContainer.location !== 'bottom' || paneContainer.getActivePaneItem() !== this.panel) {
+    const paneContainer = atom.workspace.paneContainerForItem(panel)
+    if (!paneContainer || paneContainer.location !== 'bottom' || paneContainer.getActivePaneItem() !== panel) {
       return
     }
     if (
@@ -88,6 +89,7 @@ class Panel {
     } else {
       paneContainer.hide()
     }
+    panel.doPanelResize()
   }
   dispose() {
     this.deactivating = true

--- a/package.json
+++ b/package.json
@@ -101,6 +101,12 @@
       "default": true,
       "order": 1
     },
+    "alwaysTakeMinimumSpace": {
+      "description": "Auto resizes Linter panel when there are less issues to show",
+      "type": "boolean",
+      "default": false,
+      "order": 1
+    },
     "decorateOnTreeView": {
       "type": "string",
       "description": "Underline the selected type in TreeView to indicate issues",


### PR DESCRIPTION
I really really hate this way of doing it, but it was the only way I found. CSS methods don't work because linter's parent element (which takes all the height even if linter's panel doesn't) is an `absolute` div and they don't support taking minimum heights :(

Fixes #332
Fixes #331