### PR TITLE
Handle BottomDock active pane item and improve showPanelConfig consistence

### DIFF
--- a/lib/panel/index.js
+++ b/lib/panel/index.js
@@ -32,14 +32,14 @@ class Panel {
         this.refresh()
       }),
     )
-	this.subscriptions.add(
+    this.subscriptions.add(
       atom.workspace.onDidDestroyPane(({ pane: destroyedPane }) => {
         const isPaneItemDestroyed = destroyedPane.getItems().includes(this.panel)
         if (isPaneItemDestroyed && !this.deactivating) {
           this.panel = null
           atom.config.set('linter-ui-default.showPanel', false)
         }
-      })
+      }),
     )
     this.subscriptions.add(
       atom.workspace.onDidDestroyPaneItem(({ item: paneItem }) => {
@@ -61,7 +61,7 @@ class Panel {
         this.refresh()
       }),
     )
-	this.subscriptions.add(
+    this.subscriptions.add(
       atom.workspace.getBottomDock().onDidChangeActivePaneItem(paneItem => {
         if (this.panel) {
           const paneContainer = atom.workspace.paneContainerForItem(this.panel)
@@ -74,7 +74,7 @@ class Panel {
         }
       }),
     )
-	this.subscriptions.add(
+    this.subscriptions.add(
       atom.workspace.getBottomDock().onDidChangeVisible(visible => {
         if (this.panel) {
           const paneContainer = atom.workspace.paneContainerForItem(this.panel)
@@ -85,6 +85,7 @@ class Panel {
           }
         }
       }),
+    )
     this.activationTimer = window.requestIdleCallback(() => {
       this.activate()
     })
@@ -122,11 +123,11 @@ class Panel {
     if (!paneContainer || paneContainer.location !== 'bottom') {
       return
     }
-	const isActivePanel = paneContainer.getActivePaneItem() === panel
+    const isActivePanel = paneContainer.getActivePaneItem() === panel
     const visibilityAllowed1 = this.showPanelConfig
     const visibilityAllowed2 = this.hidePanelWhenEmpty ? this.showPanelStateMessages : true
     if (visibilityAllowed1 && visibilityAllowed2) {
-	  if (!isActivePanel) {
+      if (!isActivePanel) {
         paneContainer.paneForItem(panel).activateItem(panel)
       }
       paneContainer.show()

--- a/lib/panel/index.js
+++ b/lib/panel/index.js
@@ -32,6 +32,15 @@ class Panel {
         this.refresh()
       }),
     )
+	this.subscriptions.add(
+      atom.workspace.onDidDestroyPane(({ pane: destroyedPane }) => {
+        const isPaneItemDestroyed = destroyedPane.getItems().includes(this.panel)
+        if (isPaneItemDestroyed && !this.deactivating) {
+          this.panel = null
+          atom.config.set('linter-ui-default.showPanel', false)
+        }
+      })
+    )
     this.subscriptions.add(
       atom.workspace.onDidDestroyPaneItem(({ item: paneItem }) => {
         if (paneItem instanceof PanelDock && !this.deactivating) {

--- a/lib/panel/index.js
+++ b/lib/panel/index.js
@@ -62,6 +62,19 @@ class Panel {
       }),
     )
 	this.subscriptions.add(
+      atom.workspace.getBottomDock().onDidChangeActivePaneItem(paneItem => {
+        if (this.panel) {
+          const paneContainer = atom.workspace.paneContainerForItem(this.panel)
+          const containerIsDock = paneContainer && paneContainer.location === 'bottom'
+          const isFocusIn = paneItem === this.panel
+          const externallyToggled = containerIsDock && isFocusIn !== this.showPanelConfig
+          if (externallyToggled) {
+            atom.config.set('linter-ui-default.showPanel', !this.showPanelConfig)
+          }
+        }
+      }),
+    )
+	this.subscriptions.add(
       atom.workspace.getBottomDock().onDidChangeVisible(visible => {
         if (this.panel) {
           const paneContainer = atom.workspace.paneContainerForItem(this.panel)

--- a/lib/panel/index.js
+++ b/lib/panel/index.js
@@ -95,12 +95,16 @@ class Panel {
       return
     }
     const paneContainer = atom.workspace.paneContainerForItem(panel)
-    if (!paneContainer || paneContainer.location !== 'bottom' || paneContainer.getActivePaneItem() !== panel) {
+    if (!paneContainer || paneContainer.location !== 'bottom') {
       return
     }
+	const isActivePanel = paneContainer.getActivePaneItem() === panel
     const visibilityAllowed1 = this.showPanelConfig
     const visibilityAllowed2 = this.hidePanelWhenEmpty ? this.showPanelStateMessages : true
     if (visibilityAllowed1 && visibilityAllowed2) {
+	  if (!isActivePanel) {
+        paneContainer.paneForItem(panel).activateItem(panel)
+      }
       paneContainer.show()
       panel.doPanelResize()
     } else {

--- a/lib/panel/index.js
+++ b/lib/panel/index.js
@@ -61,6 +61,17 @@ class Panel {
         this.refresh()
       }),
     )
+	this.subscriptions.add(
+      atom.workspace.getBottomDock().onDidChangeVisible(visible => {
+        if (this.panel) {
+          const paneContainer = atom.workspace.paneContainerForItem(this.panel)
+          const containerIsDock = paneContainer && paneContainer.location === 'bottom'
+          const externallyToggled = containerIsDock && visible !== this.showPanelConfig
+          if (externallyToggled) {
+            atom.config.set('linter-ui-default.showPanel', !this.showPanelConfig)
+          }
+        }
+      }),
     this.activationTimer = window.requestIdleCallback(() => {
       this.activate()
     })
@@ -107,7 +118,7 @@ class Panel {
       }
       paneContainer.show()
       panel.doPanelResize()
-    } else {
+    } else if (isActivePanel) {
       paneContainer.hide()
     }
   }


### PR DESCRIPTION
Improve showPanelConfig consistency when user interacts with BottomDock "externally" ( using Atom features, as changing active tab or hidding the Dock )

Take into account BottomDock active pane item when toggle the panel 

This PR potentially fixes : 
#425 
#518 
#537 
#547