### PR TITLE
🐛 Fix #555: Do not toggle showPanel on initial change of active panel.

### DIFF
--- a/lib/panel/index.js
+++ b/lib/panel/index.js
@@ -16,6 +16,7 @@ class Panel {
   hidePanelWhenEmpty: boolean
   showPanelStateMessages: boolean
   activationTimer: number
+  initialActiveBottomPaneItem: PanelDock | null
   constructor() {
     this.panel = null
     this.element = document.createElement('div')
@@ -24,6 +25,7 @@ class Panel {
     this.deactivating = false
     this.subscriptions = new CompositeDisposable()
     this.showPanelStateMessages = false
+    this.initialActiveBottomPaneItem = null
 
     this.subscriptions.add(this.delegate)
     this.subscriptions.add(
@@ -68,6 +70,13 @@ class Panel {
           if (!this.panel || this.getPanelLocation() !== 'bottom') {
             return
           }
+
+          // Skip first call as it is not actually a user-initiated toggle
+          if (!this.initialActiveBottomPaneItem) {
+            this.initialActiveBottomPaneItem = paneItem
+            return
+          }
+
           const isFocusIn = paneItem === this.panel
           const externallyToggled = isFocusIn !== this.showPanelConfig
           if (externallyToggled) {


### PR DESCRIPTION
Thanks for the package! It's great.

I'm not 100% sure why, but the cause of #555 appears to be the `onDidChangeActivePaneItem` handler for the bottom dock. It's getting run on startup, mistakes the run for a user-initiated focus change, and updates `showPanel` to true (since it is set to false).

I figured a quick flag for the first time it gets run would be the least-disruptive way to fix it. 😃 