### PR TITLE
Adds activation hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
       }
     }
   },
+  "activationHooks": [
+    "core:loaded-shell-environment"
+  ],
   "package-deps": [
     "intentions",
     "linter"

--- a/spec/busy-singal-spec.js
+++ b/spec/busy-singal-spec.js
@@ -37,6 +37,10 @@ describe('BusySignal', function() {
   let busySignal
 
   beforeEach(async function() {
+    // Activate activation hook
+    atom.packages.triggerDeferredActivationHooks();
+    atom.packages.triggerActivationHook('core:loaded-shell-environment');
+  
     await atom.packages.loadPackage('linter-ui-default')
     busySignal = new BusySignal()
     busySignal.attach(SignalRegistry)

--- a/spec/busy-singal-spec.js
+++ b/spec/busy-singal-spec.js
@@ -38,9 +38,9 @@ describe('BusySignal', function() {
 
   beforeEach(async function() {
     // Activate activation hook
-    atom.packages.triggerDeferredActivationHooks();
-    atom.packages.triggerActivationHook('core:loaded-shell-environment');
-  
+    atom.packages.triggerDeferredActivationHooks()
+    atom.packages.triggerActivationHook('core:loaded-shell-environment')
+
     await atom.packages.loadPackage('linter-ui-default')
     busySignal = new BusySignal()
     busySignal.attach(SignalRegistry)

--- a/spec/editor-spec.js
+++ b/spec/editor-spec.js
@@ -20,9 +20,9 @@ describe('Editor', function() {
     editor = new Editor(textEditor)
 
     // Activate activation hook
-    atom.packages.triggerDeferredActivationHooks();
-    atom.packages.triggerActivationHook('core:loaded-shell-environment');
-    
+    atom.packages.triggerDeferredActivationHooks()
+    atom.packages.triggerActivationHook('core:loaded-shell-environment')
+
     atom.packages.loadPackage('linter-ui-default')
   })
   afterEach(function() {

--- a/spec/editor-spec.js
+++ b/spec/editor-spec.js
@@ -18,6 +18,11 @@ describe('Editor', function() {
     await atom.workspace.open(__filename)
     textEditor = atom.workspace.getActiveTextEditor()
     editor = new Editor(textEditor)
+
+    // Activate activation hook
+    atom.packages.triggerDeferredActivationHooks();
+    atom.packages.triggerActivationHook('core:loaded-shell-environment');
+    
     atom.packages.loadPackage('linter-ui-default')
   })
   afterEach(function() {


### PR DESCRIPTION
 This speeds up loading of Atom, by deferring the loading of linter-ui until the core Atom shell is loaded. 