### PR TITLE
use of background color inversion for linter messages

### DIFF
--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -16,7 +16,7 @@
   max-width: 64em;
 
   .message-with-severity(@color) {
-    color: @text-color;
+    color: #fff - @inset-panel-background-color; // invert
     background-color: @inset-panel-background-color;
 
     border-left: 8px solid @color;


### PR DESCRIPTION
This uses the invert of background color for the selected linter messages in the editor. As you see, the text has more contrast with its background which makes it easier to read.

Demo for a bunch of themes:
One Dark - Atom Dark
![image](https://user-images.githubusercontent.com/16418197/87544315-d96fbb00-c66b-11ea-9711-1be8b8872e73.png)
Atom Light - Atom light
![image](https://user-images.githubusercontent.com/16418197/87544358-e7bdd700-c66b-11ea-87bd-05740c8a59e6.png)
Atom Dark - Atom Dark
![image](https://user-images.githubusercontent.com/16418197/87544697-89452880-c66c-11ea-87b9-895d042dde0c.png)
One Dark - One Dark
![image](https://user-images.githubusercontent.com/16418197/87544843-b691d680-c66c-11ea-87b9-4ea87441fb88.png)
