### PR TITLE
Rewrite rendering algorithm+ improve performance + fix memory leaks

### DIFF
--- a/lib/editor/index.js
+++ b/lib/editor/index.js
@@ -15,7 +15,7 @@ class Editor {
   tooltip: ?Tooltip
   emitter: Emitter
   markers: Map<string, BufferMarker>
-  messages: Set<LinterMessage>
+  messages: Map<key, LinterMessage>
   textEditor: TextEditor
   showTooltip: boolean
   subscriptions: CompositeDisposable
@@ -30,7 +30,7 @@ class Editor {
     this.tooltip = null
     this.emitter = new Emitter()
     this.markers = new Map()
-    this.messages = new Set()
+    this.messages = new Map()
     this.textEditor = textEditor
     this.subscriptions = new CompositeDisposable()
     this.ignoreTooltipInvocation = false
@@ -299,7 +299,7 @@ class Editor {
     for (let i = 0, length = removed.length; i < length; i++) {
       const message = removed[i]
       this.destroyMarker(message.key)
-      this.messages.delete(message)
+      this.messages.delete(message.key)
       this.markers.delete(message.key)
     }
 
@@ -314,7 +314,7 @@ class Editor {
         invalidate: 'never',
       })
       this.saveMarker(message.key, marker)
-      this.messages.add(message)
+      this.messages.set(message.key, message)
       this.decorateMarker(message, marker)
       marker.onDidChange(({ oldHeadPosition, newHeadPosition, isValid }) => {
         if (!isValid || (newHeadPosition.row === 0 && oldHeadPosition.row !== 0)) {

--- a/lib/editor/index.js
+++ b/lib/editor/index.js
@@ -299,8 +299,6 @@ class Editor {
     for (let i = 0, length = removed.length; i < length; i++) {
       const message = removed[i]
       this.destroyMarker(message.key)
-      this.messages.delete(message.key)
-      this.markers.delete(message.key)
     }
 
     for (let i = 0, length = added.length; i < length; i++) {
@@ -364,6 +362,8 @@ class Editor {
         }
       })
     }
+    this.markers.delete(key)
+    this.messages.delete(key)
   }
 
   onDidDestroy(callback: Function): Disposable {

--- a/lib/editor/index.js
+++ b/lib/editor/index.js
@@ -14,7 +14,7 @@ class Editor {
   gutter: ?TextEditorGutter
   tooltip: ?Tooltip
   emitter: Emitter
-  markers: Map<LinterMessage, BufferMarker>
+  markers: Map<string, BufferMarker>
   messages: Set<LinterMessage>
   textEditor: TextEditor
   showTooltip: boolean
@@ -292,12 +292,12 @@ class Editor {
 
     for (let i = 0, length = removed.length; i < length; i++) {
       const message = removed[i]
-      const marker = this.markers.get(message)
+      const marker = this.markers.get(message.key)
       if (marker) {
         marker.destroy()
       }
       this.messages.delete(message)
-      this.markers.delete(message)
+      this.markers.delete(message.key)
     }
 
     for (let i = 0, length = added.length; i < length; i++) {
@@ -310,7 +310,7 @@ class Editor {
       const marker = textBuffer.markRange(markerRange, {
         invalidate: 'never',
       })
-      this.markers.set(message, marker)
+      this.markers.set(message.key, marker)
       this.messages.add(message)
       this.decorateMarker(message, marker)
       marker.onDidChange(({ oldHeadPosition, newHeadPosition, isValid }) => {

--- a/lib/editor/index.js
+++ b/lib/editor/index.js
@@ -278,6 +278,12 @@ class Editor {
     }
 
     this.tooltip = new Tooltip(messages, position, this.textEditor)
+
+    // save markers of the tooltip (for destorying them in this.apply)
+    messages.forEach(message => {
+      this.saveMarker(message.key, this.tooltip.marker)
+    })
+
     this.tooltip.onDidDestroy(() => {
       this.tooltip = null
     })

--- a/lib/editor/index.js
+++ b/lib/editor/index.js
@@ -292,10 +292,7 @@ class Editor {
 
     for (let i = 0, length = removed.length; i < length; i++) {
       const message = removed[i]
-      const marker = this.markers.get(message.key)
-      if (marker) {
-        marker.destroy()
-      }
+      this.destroyMarker(message.key)
       this.messages.delete(message)
       this.markers.delete(message.key)
     }
@@ -310,7 +307,7 @@ class Editor {
       const marker = textBuffer.markRange(markerRange, {
         invalidate: 'never',
       })
-      this.markers.set(message.key, marker)
+      this.saveMarker(message.key, marker)
       this.messages.add(message)
       this.decorateMarker(message, marker)
       marker.onDidChange(({ oldHeadPosition, newHeadPosition, isValid }) => {
@@ -343,6 +340,26 @@ class Editor {
       })
     }
   }
+
+  // add marker to the message => marker map
+  saveMarker(key, marker) {
+    const allMarkers = this.markers.get(key) || []
+    allMarkers.push(marker)
+    this.markers.set(key, allMarkers)
+  }
+
+  // destroy markers of a key
+  destroyMarker(key) {
+    const markers = this.markers.get(key)
+    if (markers) {
+      markers.forEach(marker => {
+        if (marker) {
+          marker.destroy()
+        }
+      })
+    }
+  }
+
   onDidDestroy(callback: Function): Disposable {
     return this.emitter.on('did-destroy', callback)
   }

--- a/lib/editor/index.js
+++ b/lib/editor/index.js
@@ -311,8 +311,6 @@ class Editor {
       const marker = textBuffer.markRange(markerRange, {
         invalidate: 'never',
       })
-      this.saveMarker(message.key, marker)
-      this.messages.set(message.key, message)
       this.decorateMarker(message, marker)
       marker.onDidChange(({ oldHeadPosition, newHeadPosition, isValid }) => {
         if (!isValid || (newHeadPosition.row === 0 && oldHeadPosition.row !== 0)) {
@@ -327,6 +325,9 @@ class Editor {
     this.updateTooltip(this.cursorPosition)
   }
   decorateMarker(message: LinterMessage, marker: Object, paint: 'gutter' | 'editor' | 'both' = 'both') {
+    this.saveMarker(message.key, marker)
+    this.messages.set(message.key, message)
+
     if (paint === 'both' || paint === 'editor') {
       this.textEditor.decorateMarker(marker, {
         type: 'text',

--- a/lib/editor/index.js
+++ b/lib/editor/index.js
@@ -247,8 +247,13 @@ class Editor {
       name: 'linter-ui-default',
       priority,
     })
-    this.markers.forEach((marker, message) => {
-      this.decorateMarker(message, marker, 'gutter')
+    this.markers.forEach((markers: Array<BufferMarker>, key: string) => {
+      const message = this.messages.get(key)
+      if (message) {
+        for (const marker of markers) {
+          this.decorateMarker(message, marker, 'gutter')
+        }
+      }
     })
   }
   removeGutter() {

--- a/lib/editor/index.js
+++ b/lib/editor/index.js
@@ -14,8 +14,8 @@ class Editor {
   gutter: ?TextEditorGutter
   tooltip: ?Tooltip
   emitter: Emitter
-  markers: Map<string, BufferMarker>
-  messages: Map<key, LinterMessage>
+  markers: Map<string, Array<BufferMarker>>
+  messages: Map<string, LinterMessage>
   textEditor: TextEditor
   showTooltip: boolean
   subscriptions: CompositeDisposable
@@ -281,9 +281,11 @@ class Editor {
 
     // save markers of the tooltip (for destorying them in this.apply)
     messages.forEach(message => {
+      // $FlowIgnore: this.tooltip is not null
       this.saveMarker(message.key, this.tooltip.marker)
     })
 
+    // $FlowIgnore: this.tooltip is not null
     this.tooltip.onDidDestroy(() => {
       this.tooltip = null
     })
@@ -324,7 +326,7 @@ class Editor {
 
     this.updateTooltip(this.cursorPosition)
   }
-  decorateMarker(message: LinterMessage, marker: Object, paint: 'gutter' | 'editor' | 'both' = 'both') {
+  decorateMarker(message: LinterMessage, marker: BufferMarker, paint: 'gutter' | 'editor' | 'both' = 'both') {
     this.saveMarker(message.key, marker)
     this.messages.set(message.key, message)
 
@@ -347,14 +349,14 @@ class Editor {
   }
 
   // add marker to the message => marker map
-  saveMarker(key, marker) {
+  saveMarker(key: string, marker: BufferMarker) {
     const allMarkers = this.markers.get(key) || []
     allMarkers.push(marker)
     this.markers.set(key, allMarkers)
   }
 
   // destroy markers of a key
-  destroyMarker(key) {
+  destroyMarker(key: string) {
     const markers = this.markers.get(key)
     if (markers) {
       markers.forEach(marker => {

--- a/lib/editor/index.js
+++ b/lib/editor/index.js
@@ -25,6 +25,7 @@ class Editor {
   showDecorations: boolean
   showProviderName: boolean
   ignoreTooltipInvocation: boolean
+  currentLineMarker: ?BufferMarker
 
   constructor(textEditor: TextEditor) {
     this.tooltip = null
@@ -34,6 +35,7 @@ class Editor {
     this.textEditor = textEditor
     this.subscriptions = new CompositeDisposable()
     this.ignoreTooltipInvocation = false
+    this.currentLineMarker = null
 
     this.subscriptions.add(this.emitter)
     this.subscriptions.add(
@@ -127,7 +129,6 @@ class Editor {
   listenForCurrentLine() {
     this.subscriptions.add(
       this.textEditor.observeCursors(cursor => {
-        let marker
         let lastRange
         let lastEmpty
         const handlePositionChange = ({ start, end }) => {
@@ -145,16 +146,19 @@ class Editor {
             linesRange.end.row--
           }
           if (lastRange && lastRange.isEqual(linesRange) && currentEmpty === lastEmpty) return
-          if (marker) marker.destroy()
+          if (this.currentLineMarker) {
+            this.currentLineMarker.destroy()
+            this.currentLineMarker = null
+          }
           lastRange = linesRange
           lastEmpty = currentEmpty
 
-          marker = this.textEditor.markScreenRange(linesRange, {
+          this.currentLineMarker = this.textEditor.markScreenRange(linesRange, {
             invalidate: 'never',
           })
           const item = document.createElement('span')
           item.className = `line-number cursor-line linter-cursor-line ${currentEmpty ? 'cursor-line-no-selection' : ''}`
-          gutter.decorateMarker(marker, {
+          gutter.decorateMarker(this.currentLineMarker, {
             item,
             class: 'linter-row',
           })
@@ -178,7 +182,10 @@ class Editor {
         )
         subscriptions.add(
           new Disposable(function() {
-            if (marker) marker.destroy()
+            if (this.currentLineMarker) {
+              this.currentLineMarker.destroy()
+              this.currentLineMarker = null
+            }
           }),
         )
         this.subscriptions.add(subscriptions)

--- a/lib/editor/index.js
+++ b/lib/editor/index.js
@@ -3,7 +3,8 @@
 import debounce from 'sb-debounce'
 import disposableEvent from 'disposable-event'
 import { CompositeDisposable, Disposable, Emitter, Range } from 'atom'
-import type { TextEditor, BufferMarker, TextEditorGutter, Point } from 'atom'
+// $FlowIgnore: Cursor is a type
+import type { TextEditor, BufferMarker, TextEditorGutter, Point, Cursor } from 'atom'
 
 import Tooltip from '../tooltip'
 import { $range, filterMessagesByRangeOrPoint } from '../helpers'
@@ -28,6 +29,7 @@ class Editor {
   currentLineMarker: ?BufferMarker
   lastRange: ?Range
   lastEmpty: ?Range
+  lastCursorPositions: WeakMap<Cursor, Point>
 
   constructor(textEditor: TextEditor) {
     this.tooltip = null
@@ -40,6 +42,7 @@ class Editor {
     this.currentLineMarker = null
     this.lastRange = null
     this.lastEmpty = null
+    this.lastCursorPositions = new WeakMap()
 
     this.subscriptions.add(this.emitter)
     this.subscriptions.add(
@@ -102,12 +105,11 @@ class Editor {
       }),
     )
 
-    const lastCursorPositions = new WeakMap()
     this.subscriptions.add(
       textEditor.onDidChangeCursorPosition(({ cursor, newBufferPosition }) => {
-        const lastBufferPosition = lastCursorPositions.get(cursor)
+        const lastBufferPosition = this.lastCursorPositions.get(cursor)
         if (!lastBufferPosition || !lastBufferPosition.isEqual(newBufferPosition)) {
-          lastCursorPositions.set(cursor, newBufferPosition)
+          this.lastCursorPositions.set(cursor, newBufferPosition)
           this.ignoreTooltipInvocation = false
         }
         if (this.tooltipFollows === 'Mouse') {
@@ -119,7 +121,7 @@ class Editor {
       textEditor.getBuffer().onDidChangeText(() => {
         const cursors = textEditor.getCursors()
         cursors.forEach(cursor => {
-          lastCursorPositions.set(cursor, cursor.getBufferPosition())
+          this.lastCursorPositions.set(cursor, cursor.getBufferPosition())
         })
         if (this.tooltipFollows !== 'Mouse') {
           this.ignoreTooltipInvocation = true

--- a/lib/editor/index.js
+++ b/lib/editor/index.js
@@ -26,6 +26,8 @@ class Editor {
   showProviderName: boolean
   ignoreTooltipInvocation: boolean
   currentLineMarker: ?BufferMarker
+  lastRange: ?Range
+  lastEmpty: ?Range
 
   constructor(textEditor: TextEditor) {
     this.tooltip = null
@@ -36,6 +38,8 @@ class Editor {
     this.subscriptions = new CompositeDisposable()
     this.ignoreTooltipInvocation = false
     this.currentLineMarker = null
+    this.lastRange = null
+    this.lastEmpty = null
 
     this.subscriptions.add(this.emitter)
     this.subscriptions.add(
@@ -129,8 +133,6 @@ class Editor {
   listenForCurrentLine() {
     this.subscriptions.add(
       this.textEditor.observeCursors(cursor => {
-        let lastRange
-        let lastEmpty
         const handlePositionChange = ({ start, end }) => {
           const gutter = this.gutter
           if (!gutter || this.subscriptions.disposed) return
@@ -145,13 +147,13 @@ class Editor {
           if (start.row !== end.row && currentRange.end.column === 0) {
             linesRange.end.row--
           }
-          if (lastRange && lastRange.isEqual(linesRange) && currentEmpty === lastEmpty) return
+          if (this.lastRange && this.lastRange.isEqual(linesRange) && currentEmpty === this.lastEmpty) return
           if (this.currentLineMarker) {
             this.currentLineMarker.destroy()
             this.currentLineMarker = null
           }
-          lastRange = linesRange
-          lastEmpty = currentEmpty
+          this.lastRange = linesRange
+          this.lastEmpty = currentEmpty
 
           this.currentLineMarker = this.textEditor.markScreenRange(linesRange, {
             invalidate: 'never',

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -89,7 +89,7 @@ export function filterMessages(
 }
 
 export function filterMessagesByRangeOrPoint(
-  messages: Set<LinterMessage> | Array<LinterMessage>,
+  messages: Set<LinterMessage> | Array<LinterMessage> | Map<string, LinterMessage>,
   filePath: string,
   rangeOrPoint: Point | Range,
 ): Array<LinterMessage> {

--- a/lib/tooltip/index.js
+++ b/lib/tooltip/index.js
@@ -44,11 +44,20 @@ class TooltipElement {
     ReactDOM.render(<linter-messages>{children}</linter-messages>, this.element)
   }
   isValid(position: Point, messages: Set<LinterMessage>): boolean {
-    if (this.messages.length !== 1 || !messages.has(this.messages[0])) {
+    if (this.messages.length !== 1 || !this.containsMessage(messages)) {
       return false
     }
     const range = $range(this.messages[0])
     return Boolean(range && range.containsPoint(position))
+  }
+  containsMessage(messages: Set<LinterMessage>): boolean {
+    const thisKey = this.messages[0].key
+    for (const message of messages) {
+      if (message.key === thisKey) {
+        return true
+      }
+    }
+    return false
   }
   onDidDestroy(callback: () => any): Disposable {
     this.emitter.on('did-destroy', callback)

--- a/lib/tooltip/index.js
+++ b/lib/tooltip/index.js
@@ -44,14 +44,11 @@ class TooltipElement {
     ReactDOM.render(<linter-messages>{children}</linter-messages>, this.element)
   }
   isValid(position: Point, messages: Map<string, LinterMessage>): boolean {
-    if (this.messages.length !== 1 || !this.containsMessage(messages)) {
+    if (this.messages.length !== 1 || !messages.has(this.messages[0].key)) {
       return false
     }
     const range = $range(this.messages[0])
     return Boolean(range && range.containsPoint(position))
-  }
-  containsMessage(messages: Map<string, LinterMessage>): boolean {
-    return messages.has(this.messages[0].key)
   }
   onDidDestroy(callback: () => any): Disposable {
     this.emitter.on('did-destroy', callback)

--- a/lib/tooltip/index.js
+++ b/lib/tooltip/index.js
@@ -44,8 +44,11 @@ class TooltipElement {
     ReactDOM.render(<linter-messages>{children}</linter-messages>, this.element)
   }
   isValid(position: Point, messages: Set<LinterMessage>): boolean {
+    if (this.messages.length !== 1 || !messages.has(this.messages[0])) {
+      return false
+    }
     const range = $range(this.messages[0])
-    return !!(this.messages.length === 1 && messages.has(this.messages[0]) && range && range.containsPoint(position))
+    return Boolean(range && range.containsPoint(position))
   }
   onDidDestroy(callback: () => any): Disposable {
     this.emitter.on('did-destroy', callback)

--- a/lib/tooltip/index.js
+++ b/lib/tooltip/index.js
@@ -43,21 +43,15 @@ class TooltipElement {
     })
     ReactDOM.render(<linter-messages>{children}</linter-messages>, this.element)
   }
-  isValid(position: Point, messages: Set<LinterMessage>): boolean {
+  isValid(position: Point, messages: Map<string, LinterMessage>): boolean {
     if (this.messages.length !== 1 || !this.containsMessage(messages)) {
       return false
     }
     const range = $range(this.messages[0])
     return Boolean(range && range.containsPoint(position))
   }
-  containsMessage(messages: Set<LinterMessage>): boolean {
-    const thisKey = this.messages[0].key
-    for (const message of messages) {
-      if (message.key === thisKey) {
-        return true
-      }
-    }
-    return false
+  containsMessage(messages: Map<string, LinterMessage>): boolean {
+    return messages.has(this.messages[0].key)
   }
   onDidDestroy(callback: () => any): Disposable {
     this.emitter.on('did-destroy', callback)


### PR DESCRIPTION
### Description of the change

By merging https://github.com/steelbrain/linter/pull/1706 the removal now works correctly. However, that reveals some bugs in the linter-ui code which is supposed to be fixed in this pull request. The previous logic of the linter mostly rerendered all the messages from scratch. But now some are needed to be removed and that is why these bugs got revealed.

In this PR, the rendering algorithm is rewritten so only the "added" messages are rendered from scratch, and the "removed" messages are removed. It does not render all the messages every time. This greatly improves performance.

Several memory leaks were fixed in this PR.

### should be merged with https://github.com/steelbrain/linter/pull/1706
