### PR TITLE
prevent stealing focus from other panes

### DIFF
--- a/lib/panel/index.js
+++ b/lib/panel/index.js
@@ -92,6 +92,10 @@ class Panel {
               return
             }
           }
+          if (dock.getActivePaneItem() !== this.panel) {
+            // Ignore since the visibility of this panel is not changing
+            return
+          }
           const externallyToggled = visible !== this.showPanelConfig
           if (externallyToggled) {
             atom.config.set('linter-ui-default.showPanel', !this.showPanelConfig)


### PR DESCRIPTION
prevent stealing focus from other panes in dock when adding items to the bottom dock.

fixes #582 