### PR TITLE
Array check guard in editors for removed/added

### DIFF
--- a/lib/editors.js
+++ b/lib/editors.js
@@ -41,17 +41,19 @@ class Editors {
     this.firstRender = false
 
     const { editorsMap, filePaths } = getEditorsMap(this)
-    removed.forEach(function(message) {
-      const filePath = $file(message)
-      if (filePath && editorsMap[filePath]) {
-        editorsMap[filePath].removed.push(message)
-      }
-    })
     if (Array.isArray(added)) {
       added.forEach(function(message) {
         const filePath = $file(message)
         if (filePath && editorsMap[filePath]) {
           editorsMap[filePath].added.push(message)
+        }
+      })
+    }
+    if (Array.isArray(removed)) {
+      removed.forEach(function(message) {
+        const filePath = $file(message)
+        if (filePath && editorsMap[filePath]) {
+          editorsMap[filePath].removed.push(message)
         }
       })
     }

--- a/lib/editors.js
+++ b/lib/editors.js
@@ -41,18 +41,20 @@ class Editors {
     this.firstRender = false
 
     const { editorsMap, filePaths } = getEditorsMap(this)
-    added.forEach(function(message) {
-      const filePath = $file(message)
-      if (filePath && editorsMap[filePath]) {
-        editorsMap[filePath].added.push(message)
-      }
-    })
     removed.forEach(function(message) {
       const filePath = $file(message)
       if (filePath && editorsMap[filePath]) {
         editorsMap[filePath].removed.push(message)
       }
     })
+    if (Array.isArray(added)) {
+      added.forEach(function(message) {
+        const filePath = $file(message)
+        if (filePath && editorsMap[filePath]) {
+          editorsMap[filePath].added.push(message)
+        }
+      })
+    }
 
     filePaths.forEach(function(filePath) {
       const value = editorsMap[filePath]


### PR DESCRIPTION
This adds an array check for the error in #573. I can't reproduce this anymore in the new version, but it is good to add the check anyways.
Fixes https://github.com/steelbrain/linter-ui-default/issues/573
