### PR TITLE
Fix DataTip conflicts

### DIFF
--- a/lib/tooltip/index.tsx
+++ b/lib/tooltip/index.tsx
@@ -38,6 +38,26 @@ export default class TooltipElement {
       }
     })
     ReactDOM.render(<div className="linter-messages">{children}</div>, this.element)
+
+    // move box above the current editing line
+    // HACK: patch the decoration's style so it is shown above the current line
+    setTimeout(() => {
+      const hight = this.element.getBoundingClientRect().height
+      const lineHight = textEditor.getLineHeightInPixels()
+      // @ts-ignore: internal API
+      const availableHight = (position.row - textEditor.getFirstVisibleScreenRow()) * lineHight
+      if (hight < availableHight + 80) {
+        this.element.style.transform = `translateY(-${2 + lineHight + hight}px)`
+        // TODO:
+        // } else {
+        // // // move right so it does not overlap with datatip-overlay"
+        // const dataTip = textEditor.getElement().querySelector(".datatip-overlay")
+        // if (dataTip) {
+        //   this.element.style.left = dataTip.clientWidth + "px"
+        // }
+      }
+      this.element.style.visibility = 'visible'
+    }, 10)
   }
   isValid(position: Point, messages: Map<string, LinterMessage>): boolean {
     if (this.messages.length !== 1 || !messages.has(this.messages[0].key)) {

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -41,25 +41,36 @@
   .linter-message {
     &.error {
       .message-with-severity(@text-color-error);
+      &::after {
+        color: @text-color-error;
+      }
     }
     &.warning {
       .message-with-severity(@text-color-warning);
+      &::after {
+        color: @text-color-warning;
+      }
     }
     &.info {
       .message-with-severity(@text-color-info);
-      &::before {
+      &::after {
         opacity: 0;
       }
     }
 
     // Arrow pointer
-    &:last-child::before {
+    &:last-child::after {
       content: '';
-      position: absolute;
-      top: -4px;
-      left: 0;
-      border: 4px solid;
+      position: relative;
+      left: -20px;
+      top: -2px;
+      border-top: 0 solid transparent;
+      border-right: 0 solid transparent;
+      border-bottom: 8px solid;
+      border-left: 8px solid transparent;
     }
+    // TODO arrow pointer for before
+
     a {
       font-weight: bold;
     }

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -14,6 +14,7 @@
   margin-top: 3px;
   max-width: 64em;
   visibility: hidden; // controlled by JavaScript
+  padding: 5px 5px 2px 5px;
 
   .message-with-severity(@color) {
     color: #fff - @inset-panel-background-color; // invert

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -17,8 +17,8 @@
   padding: 5px 5px 2px 5px;
 
   .message-with-severity(@color) {
-    color: #fff - @inset-panel-background-color; // invert
-    background-color: @inset-panel-background-color;
+    color: @syntax-text-color;
+    background: @app-background-color;
 
     border-left: 8px solid @color;
     border-right: 1px solid fade(contrast(@inset-panel-background-color), 5%);

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -13,6 +13,7 @@
 #linter-tooltip {
   margin-top: 3px;
   max-width: 64em;
+  visibility: hidden; // controlled by JavaScript
 
   .message-with-severity(@color) {
     color: #fff - @inset-panel-background-color; // invert


### PR DESCRIPTION
- Fixes overlaps with datatips (linter messages now are positioned above the point, unless there is not enough space)
- Changes the style of the tooltips so they match datatips (atom-ide-community style)

info:
![image](https://user-images.githubusercontent.com/16418197/102887312-532a8280-441c-11eb-99ca-3e82306f3dfb.png)

error:
![image](https://user-images.githubusercontent.com/16418197/102887315-54f44600-441c-11eb-8b3f-d89a463b5865.png)

when above the page, it does not translate:
![image](https://user-images.githubusercontent.com/16418197/102887388-7bb27c80-441c-11eb-8961-6a13890ba86a.png)


Fixes https://github.com/atom-ide-community/atom-ide-datatip/issues/90