### PR TITLE
Tooltip Redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+### 3.0.0
+- Redesigned tooltip :tada: (#616)
+
 ### 2.5.2
 - fix: use @font-family (#615)
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 
 The default UI for linter.
 
-![Preview](https://cloud.githubusercontent.com/assets/4278113/23879933/1ab17e2a-0872-11e7-803d-3fe0ccfc6790.gif)
-
 ### Installation
 
 You can install it from the CLI
@@ -21,6 +19,20 @@ apm install linter-ui-default
 ```
 
 Or you can install from Settings view by searching for `linter-ui-default`.
+
+### Screenshots
+
+![tooltip](https://user-images.githubusercontent.com/16418197/106548395-8577d700-64d4-11eb-9eaa-1974f0903516.png)
+
+![tooltip with multiple messages](https://user-images.githubusercontent.com/16418197/106548492-b5bf7580-64d4-11eb-819c-178c86c652ef.png)
+
+![tooltip with fold button](https://user-images.githubusercontent.com/16418197/106548281-52354800-64d4-11eb-9d66-d26ee702cfa5.png)
+
+<!-- ![tooltip expanded](https://user-images.githubusercontent.com/16418197/106548235-421d6880-64d4-11eb-8c03-89708622043b.png) -->
+
+![full editor](https://user-images.githubusercontent.com/16418197/106548923-8b21ec80-64d5-11eb-894d-c93cb3809ebd.png)
+
+![panel gif](https://cloud.githubusercontent.com/assets/4278113/23879933/1ab17e2a-0872-11e7-803d-3fe0ccfc6790.gif)
 
 ### License
 

--- a/lib/tooltip/fix-button.tsx
+++ b/lib/tooltip/fix-button.tsx
@@ -4,7 +4,7 @@ export interface Props {
 
 export function FixButton(props: Props) {
   return (
-    <button className="linter-ui-default-fix-btn" onClick={props.onClick}>
+    <button className="fix-btn" onClick={props.onClick}>
       Fix
     </button>
   )

--- a/lib/tooltip/message.tsx
+++ b/lib/tooltip/message.tsx
@@ -96,7 +96,7 @@ export default function MessageElement(props: Props) {
   const { message, delegate } = props
 
   return (
-    <div className={`linter-message ${message.severity}`} onClick={thisOpenFile}>
+    <div className='linter-message' onClick={thisOpenFile}>
       {
         // fold butotn if has message description
         message.description && (
@@ -105,7 +105,7 @@ export default function MessageElement(props: Props) {
           </a>
         )
       }
-      <div className="linter-excerpt">
+      <div className={`linter-excerpt ${message.severity}`}>
         {
           // fix button
           canBeFixed(message) && <FixButton onClick={() => onFixClick()} />

--- a/lib/tooltip/message.tsx
+++ b/lib/tooltip/message.tsx
@@ -97,27 +97,48 @@ export default function MessageElement(props: Props) {
 
   return (
     <div className={`linter-message ${message.severity}`} onClick={thisOpenFile}>
-      {message.description && (
-        <a href="#" onClick={() => toggleDescription()}>
-          <span className={`icon linter-icon icon-${state.descriptionShow ? 'chevron-down' : 'chevron-right'}`} />
-        </a>
-      )}
+      {
+        // fold butotn if has message description
+        message.description && (
+          <a href="#" onClick={() => toggleDescription()}>
+            <span className={`icon linter-icon icon-${state.descriptionShow ? 'chevron-down' : 'chevron-right'}`} />
+          </a>
+        )
+      }
       <div className="linter-excerpt">
-        {canBeFixed(message) && <FixButton onClick={() => onFixClick()} />}
-        {delegate.showProviderName ? `${message.linterName}: ` : ''}
-        {message.excerpt}
+        {
+          // fix button
+          canBeFixed(message) && <FixButton onClick={() => onFixClick()} />
+        }
+        {
+          // provider name
+          delegate.showProviderName ? `${message.linterName}: ` : ''
+        }
+        {
+          // main message text
+          message.excerpt
+        }
       </div>{' '}
-      {message.reference && message.reference.file && (
-        <a href="#" onClick={() => visitMessage(message, true)}>
-          <span className="icon linter-icon icon-alignment-aligned-to" />
-        </a>
-      )}
-      {message.url && (
-        <a href="#" onClick={() => openExternally(message)}>
-          <span className="icon linter-icon icon-link" />
-        </a>
-      )}
-      {state.descriptionShow && <div className="linter-line">{state.description || 'Loading...'}</div>}
+      {
+        // message reference
+        message.reference && message.reference.file && (
+          <a href="#" onClick={() => visitMessage(message, true)}>
+            <span className="icon linter-icon icon-alignment-aligned-to" />
+          </a>
+        )
+      }
+      {
+        // message url
+        message.url && (
+          <a href="#" onClick={() => openExternally(message)}>
+            <span className="icon linter-icon icon-link" />
+          </a>
+        )
+      }
+      {
+        // message description
+        state.descriptionShow && <div className="linter-line">{state.description || 'Loading...'}</div>
+      }
     </div>
   )
 }

--- a/lib/tooltip/message.tsx
+++ b/lib/tooltip/message.tsx
@@ -105,7 +105,7 @@ export default function MessageElement(props: Props) {
           </a>
         )
       }
-      <div className='linter-buttons'>
+      <div className='linter-buttons-left'>
         {
           // fix button
           canBeFixed(message) && <FixButton onClick={() => onFixClick()} />
@@ -120,23 +120,25 @@ export default function MessageElement(props: Props) {
           // main message text
           message.excerpt
         }
-      </div>{' '}
-      {
-        // message reference
-        message.reference && message.reference.file && (
-          <a href="#" onClick={() => visitMessage(message, true)}>
-            <span className="icon linter-icon icon-alignment-aligned-to" />
-          </a>
-        )
-      }
-      {
-        // message url
-        message.url && (
-          <a href="#" onClick={() => openExternally(message)}>
-            <span className="icon linter-icon icon-link" />
-          </a>
-        )
-      }
+      </div>
+      <div className='linter-buttons-right'>
+        {
+          // message reference
+          message.reference && message.reference.file && (
+            <a href="#" onClick={() => visitMessage(message, true)}>
+              <span className="icon linter-icon icon-alignment-aligned-to" />
+            </a>
+          )
+        }
+        {
+          // message url
+          message.url && (
+            <a href="#" onClick={() => openExternally(message)}>
+              <span className="icon linter-icon icon-link" />
+            </a>
+          )
+        }
+      </div>
       {
         // message description
         state.descriptionShow && <div className="linter-line">{state.description || 'Loading...'}</div>

--- a/lib/tooltip/message.tsx
+++ b/lib/tooltip/message.tsx
@@ -105,11 +105,13 @@ export default function MessageElement(props: Props) {
           </a>
         )
       }
-      <div className={`linter-excerpt ${message.severity}`}>
+      <div className='linter-buttons'>
         {
           // fix button
           canBeFixed(message) && <FixButton onClick={() => onFixClick()} />
         }
+      </div>
+      <div className={`linter-excerpt ${message.severity}`}>
         {
           // provider name
           delegate.showProviderName ? `${message.linterName}: ` : ''

--- a/lib/tooltip/message.tsx
+++ b/lib/tooltip/message.tsx
@@ -105,13 +105,11 @@ export default function MessageElement(props: Props) {
           </a>
         )
       }
-      <div className='linter-buttons-left'>
+      <div className={`linter-excerpt ${message.severity}`}>
         {
           // fix button
           canBeFixed(message) && <FixButton onClick={() => onFixClick()} />
         }
-      </div>
-      <div className={`linter-excerpt ${message.severity}`}>
         {
           // provider name
           delegate.showProviderName ? `${message.linterName}: ` : ''

--- a/lib/tooltip/message.tsx
+++ b/lib/tooltip/message.tsx
@@ -120,24 +120,24 @@ export default function MessageElement(props: Props) {
           // main message text
           message.excerpt
         }
-      </div>
-      <div className='linter-buttons-right'>
-        {
-          // message reference
-          message.reference && message.reference.file && (
-            <a href="#" onClick={() => visitMessage(message, true)}>
-              <span className="icon linter-icon icon-alignment-aligned-to" />
-            </a>
-          )
-        }
-        {
-          // message url
-          message.url && (
-            <a href="#" onClick={() => openExternally(message)}>
-              <span className="icon linter-icon icon-link" />
-            </a>
-          )
-        }
+        <div className='linter-buttons-right'>
+          {
+            // message reference
+            message.reference && message.reference.file && (
+              <a href="#" onClick={() => visitMessage(message, true)}>
+                <span className="icon linter-icon icon-alignment-aligned-to" />
+              </a>
+            )
+          }
+          {
+            // message url
+            message.url && (
+              <a href="#" onClick={() => openExternally(message)}>
+                <span className="icon linter-icon icon-link" />
+              </a>
+            )
+          }
+        </div>
       </div>
       {
         // message description

--- a/lib/tooltip/message.tsx
+++ b/lib/tooltip/message.tsx
@@ -110,10 +110,12 @@ export default function MessageElement(props: Props) {
           // fix button
           canBeFixed(message) && <FixButton onClick={() => onFixClick()} />
         }
+        <div className='provider-name'>
         {
           // provider name
           delegate.showProviderName ? `${message.linterName}: ` : ''
         }
+        </div>
         {
           // main message text
           message.excerpt

--- a/lib/tooltip/message.tsx
+++ b/lib/tooltip/message.tsx
@@ -110,16 +110,18 @@ export default function MessageElement(props: Props) {
           // fix button
           canBeFixed(message) && <FixButton onClick={() => onFixClick()} />
         }
-        <div className="provider-name">
+        <div className="linter-text">
+          <div className="provider-name">
+            {
+              // provider name
+              delegate.showProviderName ? `${message.linterName}: ` : ''
+            }
+          </div>
           {
-            // provider name
-            delegate.showProviderName ? `${message.linterName}: ` : ''
+            // main message text
+            message.excerpt
           }
         </div>
-        {
-          // main message text
-          message.excerpt
-        }
         <div className="linter-buttons-right">
           {
             // message reference

--- a/lib/tooltip/message.tsx
+++ b/lib/tooltip/message.tsx
@@ -96,7 +96,7 @@ export default function MessageElement(props: Props) {
   const { message, delegate } = props
 
   return (
-    <div className='linter-message' onClick={thisOpenFile}>
+    <div className="linter-message" onClick={thisOpenFile}>
       {
         // fold butotn if has message description
         message.description && (
@@ -110,17 +110,17 @@ export default function MessageElement(props: Props) {
           // fix button
           canBeFixed(message) && <FixButton onClick={() => onFixClick()} />
         }
-        <div className='provider-name'>
-        {
-          // provider name
-          delegate.showProviderName ? `${message.linterName}: ` : ''
-        }
+        <div className="provider-name">
+          {
+            // provider name
+            delegate.showProviderName ? `${message.linterName}: ` : ''
+          }
         </div>
         {
           // main message text
           message.excerpt
         }
-        <div className='linter-buttons-right'>
+        <div className="linter-buttons-right">
           {
             // message reference
             message.reference && message.reference.file && (

--- a/lib/tooltip/message.tsx
+++ b/lib/tooltip/message.tsx
@@ -97,15 +97,15 @@ export default function MessageElement(props: Props) {
 
   return (
     <div className="linter-message" onClick={thisOpenFile}>
-      {
-        // fold butotn if has message description
-        message.description && (
-          <a href="#" onClick={() => toggleDescription()}>
-            <span className={`icon linter-icon icon-${state.descriptionShow ? 'chevron-down' : 'chevron-right'}`} />
-          </a>
-        )
-      }
       <div className={`linter-excerpt ${message.severity}`}>
+        {
+          // fold butotn if has message description
+          message.description && (
+            <a href="#" onClick={() => toggleDescription()}>
+              <span className={`icon linter-icon icon-${state.descriptionShow ? 'chevron-down' : 'chevron-right'}`} />
+            </a>
+          )
+        }
         {
           // fix button
           canBeFixed(message) && <FixButton onClick={() => onFixClick()} />

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -25,10 +25,10 @@
 
     // align button with message
     .linter-buttons-left {
-      float: left;
+      display: inline;
     }
     .linter-buttons-right {
-      float: right;
+      display: inline;
 
       // url button
       a {
@@ -38,6 +38,7 @@
 
     .linter-excerpt {
       padding: 5px;
+      display: inline;
 
       // border between messages
       &:not(:last-child) {

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -53,23 +53,23 @@
       }
     }
 
-
-    // Arrow pointer
-    &:last-child::after {
-      content: '';
-      // so the arrow does not take a row in the tooltip
-      display: block;
-      width: 0;
-      // position it below the tooltip
-      position: relative;
-      left: -20px;
-      top: 3px;
-      // triangle
-      border-top: 0 solid transparent;
-      border-right: 0 solid transparent;
-      border-bottom: 8px solid;
-      border-left: 8px solid transparent;
-    }
+    // TODO: Arrow pointer does not fit in the new design
+    // // Arrow pointer
+    // &:last-child::after {
+    //   content: '';
+    //   // so the arrow does not take a row in the tooltip
+    //   display: block;
+    //   width: 0;
+    //   // position it below the tooltip
+    //   position: relative;
+    //   left: -20px;
+    //   top: 3px;
+    //   // triangle
+    //   border-top: 0 solid transparent;
+    //   border-right: 0 solid transparent;
+    //   border-bottom: 8px solid;
+    //   border-left: 8px solid transparent;
+    // }
     // TODO arrow pointer for before
 
     a {

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -18,6 +18,8 @@
   font-family: @font-family;
 
   .linter-message {
+    padding: 10px;
+
     color: #fff - @inset-panel-background-color; // invert;
     background: @app-background-color;
 

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -24,12 +24,16 @@
     background: @app-background-color;
 
     // align button with message
-    .linter-buttons {
+    .linter-buttons-left {
       float: left;
     }
+    .linter-buttons-right {
+      float: right;
 
-    a {
-      color: @text-color;
+      // url button
+      a {
+        color: @text-color;
+      }
     }
 
     .linter-excerpt {

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -60,6 +60,10 @@
           border-color: transparent transparent @color @color;
         }
       }
+      .provider-name {
+        display: inline;
+        font-weight: bolder;
+      }
     }
 
     // TODO: Arrow pointer does not fit in the new design

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -48,7 +48,7 @@
 
     // message severity function
     .message-with-severity(@color) {
-      border-left: 8px solid @color;
+      border-left: 4px solid @color;
 
       &:last-child::before {
         border-color: transparent transparent @color @color;

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -54,7 +54,6 @@
       .provider-name {
         display: inline;
         font-weight: bolder;
-        margin-right: 0.75em;
       }
 
       // align button with message

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -44,14 +44,14 @@
       &.info {
         .message-with-severity(@text-color-info);
       }
-    }
 
-    // message severity function
-    .message-with-severity(@color) {
-      border-left: 4px solid @color;
+      // message severity function
+      .message-with-severity(@color) {
+        border-left: 4px solid @color;
 
-      &:last-child::before {
-        border-color: transparent transparent @color @color;
+        &:last-child::before {
+          border-color: transparent transparent @color @color;
+        }
       }
     }
 

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -122,11 +122,12 @@ atom-text-editor.editor .linter-row {
   background-color: @button-background-color;
   border-color: @button-border-color;
   border-radius: @component-border-radius;
+  margin-top: -10px; // css aligment is stupid
   margin-right: 5px;
-  padding: 5px 10px;
-  line-height: 100%;
-  font-size: 12px;
-  vertical-align: middle;
+  padding-inline: 10px;
+  line-height: 2em;
+  font-size: var(--editor-font-size);
+
 }
 
 .linter-gutter {

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -23,6 +23,11 @@
     color: #fff - @inset-panel-background-color; // invert;
     background: @app-background-color;
 
+    // align button with message
+    .linter-buttons {
+      float: left;
+    }
+
     a {
       color: @text-color;
     }

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -25,10 +25,10 @@
 
     // align button with message
     .linter-buttons-left {
-      display: inline;
+      float: left;
     }
     .linter-buttons-right {
-      display: inline;
+      float: right;
 
       // url button
       a {

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -25,6 +25,8 @@
 
     .linter-excerpt {
       padding: 5px;
+      display: flex;
+      align-items: center;
 
       // border between messages
       &:not(:last-child) {
@@ -52,13 +54,12 @@
       .provider-name {
         display: inline;
         font-weight: bolder;
+        margin-right: 0.5em;
       }
 
       // align button with message
       .linter-buttons-right {
-        margin-top: 5px; // TODO align
         margin-left: 10px;
-        float: right;
 
         // url button
         a {

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -56,6 +56,7 @@
 
       // align button with message
       .linter-buttons-right {
+        margin-top: 5px; // TODO align
         margin-left: 10px;
         float: right;
 

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -123,11 +123,9 @@ atom-text-editor.editor .linter-row {
   background-color: @button-background-color;
   border-color: @button-border-color;
   border-radius: @component-border-radius;
-  margin-top: -12px; // css aligment is stupid
   margin-right: 5px;
   margin-left: 5px;
-  padding-inline: 10px;
-  line-height: 2em;
+  padding: 5px 8px;
   user-select: none;
   font-size: var(--editor-font-size);
 

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -18,10 +18,8 @@
   font-family: @font-family;
 
   .message-with-severity(@color) {
-    color: #fff - @inset-panel-background-color; // invert;
-    background: @app-background-color;
-
     border-left: 8px solid @color;
+
     border-right: 1px solid fade(contrast(@inset-panel-background-color), 5%);
     &:first-child {
       border-top: 1px solid fade(contrast(@inset-panel-background-color), 5%);
@@ -33,13 +31,16 @@
     &:last-child::before {
       border-color: transparent transparent @color @color;
     }
+  }
+
+  .linter-message {
+    color: #fff - @inset-panel-background-color; // invert;
+    background: @app-background-color;
 
     a {
       color: @text-color;
     }
-  }
 
-  .linter-message {
     &.error {
       .message-with-severity(@text-color-error);
       &::after {

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -28,11 +28,8 @@
     .linter-excerpt {
       padding: 5px;
 
-      border-right: 1px solid fade(contrast(@inset-panel-background-color), 5%);
-      &:first-child {
-        border-top: 1px solid fade(contrast(@inset-panel-background-color), 5%);
-      }
-      &:last-child {
+      // border between messages
+      &:not(:last-child) {
         border-bottom: 1px solid fade(contrast(@inset-panel-background-color), 5%);
       }
     }

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -51,6 +51,11 @@
           border-color: transparent transparent @color @color;
         }
       }
+
+      .linter-text {
+        margin-left: 0.5em;
+      }
+
       .provider-name {
         display: inline;
         font-weight: bolder;

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -118,7 +118,7 @@ atom-text-editor.editor .linter-row {
   justify-content: center;
 }
 .linter-ui-default-fix-btn {
-  color: @ui-site-color-1;
+  color: @text-color;
   background-color: @button-background-color;
   border-color: @button-border-color;
   border-radius: @component-border-radius;

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -122,7 +122,7 @@ atom-text-editor.editor .linter-row {
   background-color: @button-background-color;
   border-color: @button-border-color;
   border-radius: @component-border-radius;
-  margin: 0 10px;
+  margin-right: 5px;
   padding: 5px 10px;
   line-height: 100%;
   font-size: 12px;

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -23,19 +23,8 @@
     color: #fff - @inset-panel-background-color; // invert;
     background: @app-background-color;
 
-    // align button with message
-    .linter-buttons-right {
-      float: right;
-
-      // url button
-      a {
-        color: @text-color;
-      }
-    }
-
     .linter-excerpt {
       padding: 5px;
-      display: inline;
 
       // border between messages
       &:not(:last-child) {
@@ -63,6 +52,17 @@
       .provider-name {
         display: inline;
         font-weight: bolder;
+      }
+
+      // align button with message
+      .linter-buttons-right {
+        margin-left: 10px;
+        float: right;
+
+        // url button
+        a {
+          color: @text-color;
+        }
       }
     }
 

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -38,6 +38,7 @@
 
     .linter-excerpt {
       padding: 5px;
+      margin-left: 50px;
       display: inline;
 
       // border between messages
@@ -122,10 +123,11 @@ atom-text-editor.editor .linter-row {
   background-color: @button-background-color;
   border-color: @button-border-color;
   border-radius: @component-border-radius;
-  margin-top: -10px; // css aligment is stupid
-  margin-right: 5px;
+  margin-top: -12px; // css aligment is stupid
+  margin-right: -50px;
   padding-inline: 10px;
   line-height: 2em;
+  user-select: none;
   font-size: var(--editor-font-size);
 
 }

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -76,7 +76,6 @@
         background-color: @button-background-color;
         border-color: @button-border-color;
         border-radius: @component-border-radius;
-        margin-right: 5px;
         margin-left: 5px;
         padding: 5px 8px;
         user-select: none;

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -32,6 +32,16 @@
       &:not(:last-child) {
         border-bottom: 1px solid fade(contrast(@inset-panel-background-color), 5%);
       }
+
+      &.error {
+        .message-with-severity(@text-color-error);
+      }
+      &.warning {
+        .message-with-severity(@text-color-warning);
+      }
+      &.info {
+        .message-with-severity(@text-color-info);
+      }
     }
 
     // message severity function
@@ -43,24 +53,6 @@
       }
     }
 
-    &.error {
-      .message-with-severity(@text-color-error);
-      &::after {
-        color: @text-color-error;
-      }
-    }
-    &.warning {
-      .message-with-severity(@text-color-warning);
-      &::after {
-        color: @text-color-warning;
-      }
-    }
-    &.info {
-      .message-with-severity(@text-color-info);
-      &::after {
-        opacity: 0;
-      }
-    }
 
     // Arrow pointer
     &:last-child::after {

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -54,7 +54,7 @@
       .provider-name {
         display: inline;
         font-weight: bolder;
-        margin-right: 0.5em;
+        margin-right: 0.75em;
       }
 
       // align button with message

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -64,6 +64,18 @@
           color: @text-color;
         }
       }
+
+      .fix-btn {
+        color: @text-color;
+        background-color: @button-background-color;
+        border-color: @button-border-color;
+        border-radius: @component-border-radius;
+        margin-right: 5px;
+        margin-left: 5px;
+        padding: 5px 8px;
+        user-select: none;
+        font-size: var(--editor-font-size);
+      }
     }
 
     // TODO: Arrow pointer does not fit in the new design
@@ -117,18 +129,6 @@ atom-text-editor.editor .linter-row {
   display: flex;
   align-items: center;
   justify-content: center;
-}
-.linter-ui-default-fix-btn {
-  color: @text-color;
-  background-color: @button-background-color;
-  border-color: @button-border-color;
-  border-radius: @component-border-radius;
-  margin-right: 5px;
-  margin-left: 5px;
-  padding: 5px 8px;
-  user-select: none;
-  font-size: var(--editor-font-size);
-
 }
 
 .linter-gutter {

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -17,28 +17,33 @@
   padding: 5px 5px 2px 5px;
   font-family: @font-family;
 
-  .message-with-severity(@color) {
-    border-left: 8px solid @color;
-
-    border-right: 1px solid fade(contrast(@inset-panel-background-color), 5%);
-    &:first-child {
-      border-top: 1px solid fade(contrast(@inset-panel-background-color), 5%);
-    }
-    &:last-child {
-      border-bottom: 1px solid fade(contrast(@inset-panel-background-color), 5%);
-    }
-
-    &:last-child::before {
-      border-color: transparent transparent @color @color;
-    }
-  }
-
   .linter-message {
     color: #fff - @inset-panel-background-color; // invert;
     background: @app-background-color;
 
     a {
       color: @text-color;
+    }
+
+    .linter-excerpt {
+      padding: 5px;
+
+      border-right: 1px solid fade(contrast(@inset-panel-background-color), 5%);
+      &:first-child {
+        border-top: 1px solid fade(contrast(@inset-panel-background-color), 5%);
+      }
+      &:last-child {
+        border-bottom: 1px solid fade(contrast(@inset-panel-background-color), 5%);
+      }
+    }
+
+    // message severity function
+    .message-with-severity(@color) {
+      border-left: 8px solid @color;
+
+      &:last-child::before {
+        border-color: transparent transparent @color @color;
+      }
     }
 
     &.error {

--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -24,9 +24,6 @@
     background: @app-background-color;
 
     // align button with message
-    .linter-buttons-left {
-      float: left;
-    }
     .linter-buttons-right {
       float: right;
 
@@ -38,7 +35,6 @@
 
     .linter-excerpt {
       padding: 5px;
-      margin-left: 50px;
       display: inline;
 
       // border between messages
@@ -124,7 +120,8 @@ atom-text-editor.editor .linter-row {
   border-color: @button-border-color;
   border-radius: @component-border-radius;
   margin-top: -12px; // css aligment is stupid
-  margin-right: -50px;
+  margin-right: 5px;
+  margin-left: 5px;
   padding-inline: 10px;
   line-height: 2em;
   user-select: none;


### PR DESCRIPTION
This redesigns the linter tooltip. 

### Goals

The goals and requirements:
- The tooltips should look similar to datatips
- Respecting the data: 
	- separate fix buttons, reference buttons, etc. for each message that can come from different providers
- Fast to use: 
	- fix button should be on the left so the users can quickly click on it (based on their muscle memory) without the need for moving the mouse to the far right
	- less-used buttons (like URL button) are placed on the right to prevent visual cluttering 
- Minimum empty space

### Screenshots


![image](https://user-images.githubusercontent.com/16418197/106548492-b5bf7580-64d4-11eb-819c-178c86c652ef.png)


![image](https://user-images.githubusercontent.com/16418197/106548395-8577d700-64d4-11eb-9eaa-1974f0903516.png)


![image](https://user-images.githubusercontent.com/16418197/106548281-52354800-64d4-11eb-9d66-d26ee702cfa5.png)

![image](https://user-images.githubusercontent.com/16418197/106548235-421d6880-64d4-11eb-8c03-89708622043b.png)
