### PR TITLE
fix: move the linter tooltip down when there is not enough space on top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+### 3.2.3
+- fix: move the linter tooltip down when there is not enough space on top
+
 ### 3.2.2
 - Update deps
 

--- a/lib/tooltip/index.tsx
+++ b/lib/tooltip/index.tsx
@@ -1,6 +1,6 @@
 import { render } from 'solid-js/web'
 import type * as Solid from 'solid-js'
-import { CompositeDisposable, Emitter } from 'atom'
+import { CompositeDisposable, Emitter, TextEditorElement } from 'atom'
 import type { Disposable, Point, TextEditor, DisplayMarker } from 'atom'
 import Delegate from './delegate'
 import MessageElement from './message'
@@ -54,13 +54,16 @@ export default class TooltipElement {
         if (overlay) {
           overlay.style.transform = `translateY(-${2 + lineHight + hight}px)`
         }
-        // TODO:
-        // } else {
-        // // // move right so it does not overlap with datatip-overlay"
-        // const dataTip = textEditor.getElement().querySelector(".datatip-overlay")
-        // if (dataTip) {
-        //   this.element.style.left = dataTip.clientWidth + "px"
-        // }
+      } else {
+        // move down so it does not overlap with datatip-overlay
+        // @ts-ignore
+        const dataTip = (textEditor.getElement() as TextEditorElement).querySelector('.datatip-overlay') as HTMLElement
+        if (dataTip) {
+          const overlay = this.element.parentElement
+          if (overlay) {
+            overlay.style.transform = `translateY(${dataTip.clientHeight}px)`
+          }
+        }
       }
       this.element.style.visibility = 'visible'
     }, 50)


### PR DESCRIPTION
Normally, Linter tooltip is rendered above the line, but if there is not enough space it will move below the datatip.

![image](https://user-images.githubusercontent.com/16418197/107166817-bc3e6900-697c-11eb-9e6f-1b94d90b7aa3.png)
