### PR TITLE
Don't propagate messages if filePath is undefined

### DIFF
--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -66,7 +66,7 @@ export function filterMessages(
     if (!message || !message.location) {
       return
     }
-    if ((!filePath || $file(message) === filePath) && (!severity || message.severity === severity)) {
+    if (($file(message) === filePath) && (!severity || message.severity === severity)) {
       filtered.push(message)
     }
   })


### PR DESCRIPTION
I found out that if I had a file with linter warnings, when I opened up a new file, this new, empty file would be decorated as if **every line** had a linter error (example below - notice that it also confuses the UI, as it now thinks that the error is on the _first line_).

![Linter error](https://user-images.githubusercontent.com/138037/189581448-eefcf77b-e5ba-4105-b9ef-4534b3c5ba96.gif)


So I found that, in `filterMessages`, we get all messages and always add the message in the editor if `filePath` is not defined. This seems weird, and removing that line solves the issue, so I'm proposing this change. Let me know if there's something extra that I need to be aware of

Fixes #667